### PR TITLE
Support JSON-encoded private keys, as generated by geth/parity

### DIFF
--- a/microraiden/README.md
+++ b/microraiden/README.md
@@ -27,13 +27,13 @@ python3 -m microraiden.examples.demo_proxy --private-key <private_key_file> star
 ```
 or
 ```bash
-python3 -m microraiden.examples.wikipaydia --private-key <private_key_file> start
+python3 -m microraiden.examples.wikipaydia --private-key <private_key_file> --private-key-password-file <password_file> start
 ```
-By default, the web server listens on `0.0.0.0:5000`, and an Ethereum node RPC interface is expected to respond on http://localhost:8545. The private key file should contain the hex encoded private key and must be readable and writable only by the owner to be accepted (`-rw-------`).
+By default, the web server listens on `0.0.0.0:5000`, and an Ethereum node RPC interface is expected to respond on http://localhost:8545. The private key file should be in the JSON format produced by Geth/Parity and must be readable and writable only by the owner to be accepted (`-rw-------`). A ``--private-key-password-file`` option can be specified, containing the password for the private key in the first line of the file. If it's not provided, the password will be prompted interactively.
 
 ### M2M Client
 ```bash
-python3 -m microraiden.examples.m2m_client --key-path <path to private key file>
+python3 -m microraiden.examples.m2m_client --key-path <path to private key file> --key-password-path <password file>
 ```
 
 ## Library usage
@@ -46,9 +46,9 @@ from microraiden import Client
 client = Client('<hex-encoded private key>')
 ```
 
-Alternatively you can specify a path to a file containing the private key, again in a hex-encoded format, with or without a leading `0x` prefix.
+Alternatively you can specify a path to a JSON private key, optionally specifying a file containing the password. If it's not provided, it'll be prompted interactively.
 ```python
-client = Client(key_path='<path to private key file>'
+client = Client(key_path='<path to private key file>', key_password_file='<path to password file>')
 ```
 
 This client object allows interaction with the blockchain and offline-signing of transactions and Raiden balance proofs.

--- a/microraiden/microraiden/click_helpers.py
+++ b/microraiden/microraiden/click_helpers.py
@@ -40,6 +40,7 @@ pass_app = click.make_pass_decorator(PaywalledProxy)
 )
 @click.option(
     '--private-key',
+    required=True,
     help='Path to private key file of the proxy',
     type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -9,6 +9,7 @@ from eth_utils import decode_hex, is_same_address
 from web3 import Web3
 from web3.providers.rpc import RPCProvider
 
+from microraiden.utils import get_private_key
 from microraiden.config import CHANNEL_MANAGER_ADDRESS, TOKEN_ADDRESS, GAS_LIMIT, GAS_PRICE, \
     NETWORK_NAMES
 from microraiden.contract_proxy import ContractProxy, ChannelContractProxy
@@ -26,6 +27,7 @@ class Client:
             self,
             privkey: str = None,
             key_path: str = None,
+            key_password_path: str = None,
             datadir: str = click.get_app_dir('microraiden'),
             channel_manager_address: str = CHANNEL_MANAGER_ADDRESS,
             token_address: str = TOKEN_ADDRESS,
@@ -53,8 +55,8 @@ class Client:
 
         # Load private key from file if none is specified on command line.
         if not privkey:
-            with open(key_path) as keyfile:
-                self.privkey = keyfile.readline()[:-1]
+            self.privkey = get_private_key(key_path, key_password_path)
+            assert self.privkey is not None
 
         os.makedirs(datadir, exist_ok=True)
         assert os.path.isdir(datadir)

--- a/microraiden/microraiden/close_all_channels.py
+++ b/microraiden/microraiden/close_all_channels.py
@@ -30,6 +30,7 @@ log = logging.getLogger('close_all_channels')
 @click.command()
 @click.option(
     '--private-key',
+    required=True,
     help='Path to private key file of the proxy',
     type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )

--- a/microraiden/microraiden/close_all_channels.py
+++ b/microraiden/microraiden/close_all_channels.py
@@ -8,7 +8,6 @@ import traceback
 import click
 from eth_utils import (
     decode_hex,
-    is_hex,
     is_same_address,
 )
 from ethereum.tester import TransactionFailed
@@ -35,6 +34,12 @@ log = logging.getLogger('close_all_channels')
     type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )
 @click.option(
+    '--private-key-password-file',
+    default=None,
+    help='Path to file containing password for the JSON-encoded private key',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
+@click.option(
     '--state-file',
     default=None,
     help='State file of the proxy'
@@ -44,18 +49,9 @@ log = logging.getLogger('close_all_channels')
     default=None,
     help='Ethereum address of the channel manager contract'
 )
-def main(private_key, state_file, channel_manager_address):
+def main(private_key, private_key_password_file, state_file, channel_manager_address):
+    private_key = utils.get_private_key(private_key, private_key_password_file)
     if private_key is None:
-        log.fatal("No private key provided")
-        sys.exit(1)
-    if utils.check_permission_safety(private_key) is False:
-        log.fatal("Private key file %s must be readable only by its owner." % (private_key))
-        sys.exit(1)
-    with open(private_key) as keyfile:
-        private_key = keyfile.readline()[:-1]
-    print(len(decode_hex(private_key)), is_hex(private_key))
-    if not is_hex(private_key) or len(decode_hex(private_key)) != 32:
-        log.fatal("Private key must be specified as 32 hex encoded bytes")
         sys.exit(1)
 
     receiver_address = privkey_to_addr(private_key)

--- a/microraiden/microraiden/examples/echo_client.py
+++ b/microraiden/microraiden/examples/echo_client.py
@@ -10,11 +10,22 @@ import requests
 
 
 @click.command()
-@click.option('--key-path', required=True, help='Path to private key file.')
+@click.option(
+    '--key-path',
+    required=True,
+    help='Path to private key file.',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
+@click.option(
+    '--key-password-path',
+    default=None,
+    help='Path to file containing password for private key.',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
 @click.option('--resource', required=True, help='Get this resource.')
-def run(key_path, resource):
+def run(key_path, key_password_path, resource):
     # create the client
-    with Client(key_path=key_path) as client:
+    with Client(key_path=key_path, key_password_path=key_password_path) as client:
         m2mclient = DefaultHTTPClient(
             client,
             'localhost',

--- a/microraiden/microraiden/examples/m2m_client.py
+++ b/microraiden/microraiden/examples/m2m_client.py
@@ -17,7 +17,18 @@ log = logging.getLogger(__name__)
 @click.option('--datadir', help='Raiden data directory.')
 @click.option('--rpc-endpoint', help='Address of the Ethereum RPC server.')
 @click.option('--rpc-port', help='Ethereum RPC port.')
-@click.option('--key-path', required=True, help='Path to private key file.')
+@click.option(
+    '--key-path',
+    required=True,
+    help='Path to private key file.',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
+@click.option(
+    '--key-password-path',
+    default=None,
+    help='Path to file containing password for private key.',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True)
+)
 @click.option('--close-channels', default=False, is_flag=True, type=bool,
               help='Close all open channels before exiting.')
 @click.option(

--- a/microraiden/microraiden/utils.py
+++ b/microraiden/microraiden/utils.py
@@ -29,12 +29,23 @@ def check_permission_safety(path):
 
 
 def get_private_key(key_path, password_path=None):
-    if key_path is None or not os.path.exists(key_path):
-        log.fatal("No private key file found")
+    """Open a JSON-encoded private key and return it
+
+    If a password file is provided, uses it to decrypt the key. If not, the
+    password is asked interactively. Raw hex-encoded private keys are supported,
+    but deprecated."""
+
+    assert key_path, key_path
+    if not os.path.exists(key_path):
+        log.fatal("%s: no such file", key_path)
         return None
 
     if not check_permission_safety(key_path):
         log.fatal("Private key file %s must be readable only by its owner.", key_path)
+        return None
+
+    if password_path and not check_permission_safety(password_path):
+        log.fatal("Password file %s must be readable only by its owner.", password_path)
         return None
 
     with open(key_path) as keyfile:


### PR DESCRIPTION
Support JSON private keys.
Old format (raw hex encoded) is still supported, but will generate a warning, and should be considered deprecated in the future, as it's less secure and not standardized.

It will **interactively** ask for the password for decryption of the private key.
Optionally, CLI tools now have an option to pass the path of a file containing the password, for non-interactive opening of the private key (`docker` environments, scripting): `--private-key-password-file` for the proxy, `--key-password-path` for python Client/m2m.

Fix #100 .