### PR TITLE
Use token contract address from channel manager

### DIFF
--- a/microraiden/microraiden/channel_manager.py
+++ b/microraiden/microraiden/channel_manager.py
@@ -609,6 +609,9 @@ class ChannelManager(gevent.Greenlet):
     def node_online(self):
         return self.blockchain.is_connected.is_set()
 
+    def get_token_address(self):
+        return self.token_contract.address
+
 
 class Channel(object):
     """A channel between two parties."""

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -10,8 +10,7 @@ from web3 import Web3
 from web3.providers.rpc import RPCProvider
 
 from microraiden.utils import get_private_key
-from microraiden.config import CHANNEL_MANAGER_ADDRESS, TOKEN_ADDRESS, GAS_LIMIT, GAS_PRICE, \
-    NETWORK_NAMES
+from microraiden.config import CHANNEL_MANAGER_ADDRESS, GAS_LIMIT, GAS_PRICE, NETWORK_NAMES
 from microraiden.contract_proxy import ContractProxy, ChannelContractProxy
 from microraiden.crypto import privkey_to_addr
 from .channel import Channel
@@ -30,7 +29,6 @@ class Client:
             key_password_path: str = None,
             datadir: str = click.get_app_dir('microraiden'),
             channel_manager_address: str = CHANNEL_MANAGER_ADDRESS,
-            token_address: str = TOKEN_ADDRESS,
             rpc: RPCProvider = None,
             web3: Web3 = None,
             channel_manager_proxy: ChannelContractProxy = None,
@@ -48,7 +46,6 @@ class Client:
         self.privkey = privkey
         self.datadir = datadir
         self.channel_manager_address = channel_manager_address
-        self.token_address = token_address
         self.web3 = web3
         self.channel_manager_proxy = channel_manager_proxy
         self.token_proxy = token_proxy
@@ -92,11 +89,14 @@ class Client:
                     GAS_LIMIT
                 )
 
+            token_address = self.channel_manager_proxy.contract.call().token_address()
             if not token_proxy:
                 token_abi = contract_abis[TOKEN_ABI_NAME]['abi']
                 self.token_proxy = ContractProxy(
                     self.web3, self.privkey, token_address, token_abi, GAS_PRICE, GAS_LIMIT
                 )
+            else:
+                assert is_same_address(self.token_proxy.address, token_address)
 
         assert self.web3
         assert self.channel_manager_proxy

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -20,7 +20,6 @@ NETWORK_NAMES = {
 }
 
 CHANNEL_MANAGER_ADDRESS = '0xffa52825c7997dd2be80fb91080500a52abd6d5b'
-TOKEN_ADDRESS = '0x04c7f744a0c751d89e99ae79a39060ec6f3c4397'
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
 JSLIB_DIR = os.path.join(HTML_DIR, 'js')

--- a/microraiden/microraiden/make_helpers.py
+++ b/microraiden/microraiden/make_helpers.py
@@ -28,11 +28,13 @@ def make_contract_proxy(web3, private_key, contract_address):
 def make_channel_manager(private_key: str, state_filename: str, web3):
     contracts_abi_path = os.path.join(os.path.dirname(__file__), 'data/contracts.json')
     abi = json.load(open(contracts_abi_path))['ERC223Token']['abi']
-    token_contract = web3.eth.contract(abi=abi, address=config.TOKEN_ADDRESS)
+    channel_manager_proxy = make_contract_proxy(web3, private_key, config.CHANNEL_MANAGER_ADDRESS)
+    token_address = channel_manager_proxy.contract.call().token_address()
+    token_contract = web3.eth.contract(abi=abi, address=token_address)
     try:
         return ChannelManager(
             web3,
-            make_contract_proxy(web3, private_key, config.CHANNEL_MANAGER_ADDRESS),
+            channel_manager_proxy,
             token_contract,
             private_key,
             state_filename=state_filename

--- a/microraiden/microraiden/proxy/resources/expensive.py
+++ b/microraiden/microraiden/proxy/resources/expensive.py
@@ -207,7 +207,7 @@ class Expensive(Resource):
             header.CONTRACT_ADDRESS: self.contract_address,
             header.RECEIVER_ADDRESS: self.receiver_address,
             header.PRICE: price,
-            header.TOKEN_ADDRESS: config.TOKEN_ADDRESS
+            header.TOKEN_ADDRESS: self.channel_manager.get_token_address()
         })
         if gen_ui is True:
             return self.get_webUI_reply(content, proxy_handle, price, headers)
@@ -219,8 +219,12 @@ class Expensive(Resource):
         headers.update({
             "Content-Type": "text/html",
         })
-        data = proxy_handle.get_paywall(content, self.receiver_address,
-                                        price, config.TOKEN_ADDRESS)
+        data = proxy_handle.get_paywall(
+            content,
+            self.receiver_address,
+            price,
+            self.channel_manager.get_token_address()
+        )
         reply = make_response(data, 402, headers)
         for hdr in (header.GATEWAY_PATH,
                     header.CONTRACT_ADDRESS,

--- a/microraiden/microraiden/test/config.py
+++ b/microraiden/microraiden/test/config.py
@@ -3,7 +3,6 @@ from eth_utils import denoms
 from microraiden.crypto import privkey_to_addr
 
 CHANNEL_MANAGER_ADDRESS = '0xeb244b0502a2d3867e5cab2347c6e1cdeb5e1eef'
-TOKEN_ADDRESS = '0xc97c510f7d79057c8ae98e0ff8b3841e824cb4b5'
 API_PATH = "/api/1"
 GAS_LIMIT = 200000
 GAS_PRICE = 5 * denoms.gwei

--- a/microraiden/microraiden/test/fixtures/client.py
+++ b/microraiden/microraiden/test/fixtures/client.py
@@ -64,7 +64,6 @@ def client(
         client_token_proxy,
         datadir,
         channel_manager_contract_address,
-        token_contract_address
 ):
     client = Client(
         privkey=sender_privkey,
@@ -72,7 +71,6 @@ def client(
         token_proxy=client_token_proxy,
         datadir=datadir,
         channel_manager_address=channel_manager_contract_address,
-        token_address=token_contract_address
     )
     yield client
     client.close()

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -22,7 +22,6 @@ from microraiden.crypto import (
 )
 from microraiden.test.config import (
     CHANNEL_MANAGER_ADDRESS,
-    TOKEN_ADDRESS,
     FAUCET_ADDRESS,
     FAUCET_PRIVKEY,
     GAS_PRICE,
@@ -62,12 +61,17 @@ def deploy_channel_manager_contract(web3, deployer_address, channel_manager_abi,
 
 
 @pytest.fixture(scope='session')
-def token_contract_address(use_tester, web3, deployer_address, token_abi, token_bytecode):
+def token_contract_address(use_tester, web3, deployer_address, token_abi, token_bytecode,
+                           channel_manager_abi):
     if use_tester:
         contract = deploy_token_contract(web3, deployer_address, token_abi, token_bytecode)
         return contract.address
     else:
-        return TOKEN_ADDRESS
+        channel_manager_contract = web3.eth.contract(
+            abi=channel_manager_abi,
+            address=CHANNEL_MANAGER_ADDRESS
+        )
+        return channel_manager_contract.call().token_address()
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/test_client.py
+++ b/microraiden/microraiden/test/test_client.py
@@ -102,7 +102,6 @@ def test_filelock(
         'token_proxy': client_token_proxy,
         'datadir': datadir,
         'channel_manager_address': channel_manager_contract_address,
-        'token_address': token_contract_address
     }
     client = Client(**kwargs)
     client.close()


### PR DESCRIPTION
The address of the token contract doesn't have to be configured, as it's stored in the channel manager contract.