### PR TITLE
Solc 0.4.17 fixes

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -76,7 +76,7 @@ contract RaidenMicroTransferChannels {
     /// @dev Constructor for creating the Raiden microtransfer channels contract.
     /// @param _token The address of the Token used by the channels.
     /// @param _challenge_period A fixed number of blocks representing the challenge period after a sender requests the closing of the channel without the receiver's signature.
-    function RaidenMicroTransferChannels(address _token, uint8 _challenge_period) {
+    function RaidenMicroTransferChannels(address _token, uint8 _challenge_period) public {
         require(_token != 0x0);
         require(addressHasCode(_token));
         require(_challenge_period > 0);
@@ -102,10 +102,10 @@ contract RaidenMicroTransferChannels {
         address _receiver,
         uint32 _open_block_number)
         public
-        constant
+        pure
         returns (bytes32 data)
     {
-        return sha3(_sender, _receiver, _open_block_number);
+        return keccak256(_sender, _receiver, _open_block_number);
     }
 
     /// @dev Returns a hash of the balance message needed to be signed by the sender.
@@ -118,7 +118,7 @@ contract RaidenMicroTransferChannels {
         uint32 _open_block_number,
         uint192 _balance)
         public
-        constant
+        pure
         returns (string)
     {
         string memory str = concat("Receiver: 0x", addressToString(_receiver));
@@ -162,7 +162,7 @@ contract RaidenMicroTransferChannels {
 
 
         // Hash the prefixed message string
-        bytes32 prefixed_message_hash = sha3(prefixed_message);
+        bytes32 prefixed_message_hash = keccak256(prefixed_message);
 
         // Derive address from signature
         address signer = ECVerify.ecverify(prefixed_message_hash, _balance_msg_sig);
@@ -439,7 +439,7 @@ contract RaidenMicroTransferChannels {
     /// @return The maximum between the two provided numbers.
     function max(uint192 a, uint192 b)
         internal
-        constant
+        pure
         returns (uint)
     {
         if (a > b) {
@@ -455,7 +455,7 @@ contract RaidenMicroTransferChannels {
     /// @return The minimum between the two provided numbers.
     function min(uint192 a, uint192 b)
         internal
-        constant
+        pure
         returns (uint)
     {
         if (a < b) {
@@ -471,7 +471,7 @@ contract RaidenMicroTransferChannels {
     function addressFromData (
         bytes b)
         internal
-        constant
+        pure
         returns (address)
     {
         bytes20 addr;
@@ -489,7 +489,7 @@ contract RaidenMicroTransferChannels {
     function blockNumberFromData(
         bytes b)
         internal
-        constant
+        pure
         returns (uint32)
     {
         bytes4 block_number;
@@ -524,6 +524,7 @@ contract RaidenMicroTransferChannels {
         uint src,
         uint len)
         private
+        pure
     {
         // Copy word-length chunks while possible
         for(; len >= 32; len -= 32) {
@@ -547,7 +548,7 @@ contract RaidenMicroTransferChannels {
         string _self,
         string _other)
         internal
-        constant
+        pure
         returns (string)
     {
         uint self_len = bytes(_self).length;
@@ -571,7 +572,7 @@ contract RaidenMicroTransferChannels {
     function uintToString(
         uint v)
         internal
-        constant
+        pure
         returns (string)
     {
         bytes32 ret;
@@ -602,10 +603,9 @@ contract RaidenMicroTransferChannels {
         return string(bytesStringTrimmed);
     }
 
-    function addressToString(
-        address x)
+    function addressToString(address x)
         internal
-        constant
+        pure
         returns (string)
     {
         bytes memory str = new bytes(40);
@@ -621,7 +621,7 @@ contract RaidenMicroTransferChannels {
 
     function char(byte b)
         internal
-        constant
+        pure
         returns (byte c)
     {
         if (b < 10) {

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -403,7 +403,7 @@ contract RaidenMicroTransferChannels {
         private
     {
         bytes32 key = getKey(_sender, _receiver, _open_block_number);
-        Channel channel = channels[key];
+        Channel memory channel = channels[key];
 
         require(channel.open_block_number != 0);
         require(_balance <= channel.deposit);

--- a/contracts/contracts/Token/Token.sol
+++ b/contracts/contracts/Token/Token.sol
@@ -24,10 +24,10 @@ contract Token {
     uint256 public totalSupply;
 
     /*
-    NOTE:
-    The following variables were optional. Now, they are included in ERC 223 interface.
-    They allow one to customise the token contract & in no way influences the core functionality.
-    */
+     * NOTE:
+     * The following variables were optional. Now, they are included in ERC 223 interface.
+     * They allow one to customise the token contract & in no way influences the core functionality.
+     */
     string public name;                   //fancy name: eg Simon Bucks
     uint8 public decimals;                //How many decimals to show. ie. There could 1000 base units with 3 decimals. Meaning 0.980 SBX = 980 base units. It's like comparing 1 wei to 1 ether.
     string public symbol;                 //An identifier: eg SBX

--- a/contracts/contracts/Token/Token.sol
+++ b/contracts/contracts/Token/Token.sol
@@ -24,18 +24,49 @@ contract Token {
     uint256 public totalSupply;
 
     /*
-     * ERC 20
-     */
-    function balanceOf(address _owner) public constant returns (uint256 balance);
-    function transfer(address _to, uint256 _value) public returns (bool success);
-    function transferFrom(address _from, address _to, uint256 _value) public returns (bool success);
-    function approve(address _spender, uint256 _value) public returns (bool success);
-    function allowance(address _owner, address _spender) public constant returns (uint256 remaining);
+    NOTE:
+    The following variables were optional. Now, they are included in ERC 223 interface.
+    They allow one to customise the token contract & in no way influences the core functionality.
+    */
+    string public name;                   //fancy name: eg Simon Bucks
+    uint8 public decimals;                //How many decimals to show. ie. There could 1000 base units with 3 decimals. Meaning 0.980 SBX = 980 base units. It's like comparing 1 wei to 1 ether.
+    string public symbol;                 //An identifier: eg SBX
 
-    /*
-     * ERC 223
-     */
+
+    /// @param _owner The address from which the balance will be retrieved.
+    /// @return The balance.
+    function balanceOf(address _owner) public constant returns (uint256 balance);
+
+    /// @notice send `_value` token to `_to` from `msg.sender`.
+    /// @param _to The address of the recipient.
+    /// @param _value The amount of token to be transferred.
+    /// @param _data Data to be sent to `tokenFallback.
+    /// @return Returns success of function call.
     function transfer(address _to, uint256 _value, bytes _data) public returns (bool success);
+
+    /// @notice send `_value` token to `_to` from `msg.sender`.
+    /// @param _to The address of the recipient.
+    /// @param _value The amount of token to be transferred.
+    /// @return Whether the transfer was successful or not.
+    function transfer(address _to, uint256 _value) public returns (bool success);
+
+    /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`.
+    /// @param _from The address of the sender.
+    /// @param _to The address of the recipient.
+    /// @param _value The amount of token to be transferred.
+    /// @return Whether the transfer was successful or not.
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool success);
+
+    /// @notice `msg.sender` approves `_spender` to spend `_value` tokens.
+    /// @param _spender The address of the account able to transfer the tokens.
+    /// @param _value The amount of tokens to be approved for transfer.
+    /// @return Whether the approval was successful or not.
+    function approve(address _spender, uint256 _value) public returns (bool success);
+
+    /// @param _owner The address of the account owning tokens.
+    /// @param _spender The address of the account able to transfer the tokens.
+    /// @return Amount of remaining tokens allowed to spent.
+    function allowance(address _owner, address _spender) public constant returns (uint256 remaining);
 
     /*
      * Events


### PR DESCRIPTION
Still leaves one warning though.

```
contracts/contracts/RaidenMicroTransferChannels.sol:167:26: Warning: Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.                                                                    
        address signer = ECVerify.ecverify(prefixed_message_hash, _balance_msg_sig);                                                                                                                                                                                            
                         ^--------------------------------------------------------^
```

We can't mark the ECRecover lib as pure due to it's assembly code doing a `CALL` into what is I assume the ecrecover precompiled contract, but the solidity compiler is not smart enough to recognize this yet so if you mark all the contracts in ECRecover lib as pure as they should be [this](https://github.com/raiden-network/microraiden/blob/master/contracts/contracts/lib/ECVerify.sol#L5) one fails with:

```
contracts/contracts/lib/ECVerify.sol:16:20: Error: Function declared as pure, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.                                                                                      
            ret := call(3000, 1, 0, size, 128, size, 32)              
```