### PR TITLE
Add versioning to the RaidenMicroTransferChannels contract

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -13,6 +13,8 @@ contract RaidenMicroTransferChannels {
     address public owner;
     address public token_address;
     uint8 public challenge_period;
+    string public constant version = '1.0.0';
+    address public latest_version_address;
     string constant prefix = "\x19Ethereum Signed Message:\n";
 
     Token token;
@@ -37,6 +39,11 @@ contract RaidenMicroTransferChannels {
 
     modifier isToken() {
         require(msg.sender == token_address);
+        _;
+    }
+
+    modifier isOwner() {
+        require(msg.sender == owner);
         _;
     }
 
@@ -88,9 +95,21 @@ contract RaidenMicroTransferChannels {
         challenge_period = _challenge_period;
     }
 
+    /// @dev Sets the address for the latest contract version
+    /// @param _latest_version_address The address for the latest contract version.
+    function setLatestVersionAddress(address _latest_version_address) public isOwner {
+        require(addressHasCode(_latest_version_address));
+        latest_version_address = _latest_version_address;
+    }
+
     /*
      *  Public helper functions (constant)
      */
+
+    /// @dev Returns the address for the latest contract version.
+    function getLatestVersionAddress() public view returns(address) {
+        return latest_version_address;
+    }
 
     /// @dev Returns the unique channel identifier used in the contract.
     /// @param _sender The address that sends tokens.

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -105,12 +105,6 @@ contract RaidenMicroTransferChannels {
     /*
      *  Public helper functions (constant)
      */
-
-    /// @dev Returns the address for the latest contract version.
-    function getLatestVersionAddress() public view returns(address) {
-        return latest_version_address;
-    }
-
     /// @dev Returns the unique channel identifier used in the contract.
     /// @param _sender The address that sends tokens.
     /// @param _receiver The address that receives tokens.

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -13,8 +13,15 @@ contract RaidenMicroTransferChannels {
     address public owner;
     address public token_address;
     uint8 public challenge_period;
+
+    // Contract semantic version
     string public constant version = '1.0.0';
+
+    // Address of the latest deployed version of the contract. This is set
+    // by the owner during a new contract deployment for all outdated contracts.
+    // Outdated contracts can still be used.
     address public latest_version_address;
+
     string constant prefix = "\x19Ethereum Signed Message:\n";
 
     Token token;

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -4,11 +4,14 @@ global token
 global logs
 global challenge_period
 
+
+uraiden_contract_version = '1.0.0'
 decimals_params = [
     18,
     2,
     0
 ]
+
 
 @pytest.fixture(params=decimals_params)
 def decimals(request):

--- a/contracts/tests/test_raidenchannels.py
+++ b/contracts/tests/test_raidenchannels.py
@@ -8,6 +8,7 @@ from ethereum import tester
 from utils import sign
 
 from tests.fixtures import (
+    uraiden_contract_version,
     create_contract,
     contract,
     token_contract,
@@ -163,6 +164,26 @@ def channel(contract, web3):
     open_block_number = get_last_open_block_number(contract)
 
     return (A, B, open_block_number)
+
+
+def test_version(web3, contract, channels_contract):
+    (Owner, A) = web3.eth.accounts[:2]
+    other_contract = channels_contract([token.address, 10], {'from': A})
+
+    assert contract.call().version() == uraiden_contract_version
+    assert contract.call().latest_version_address() == '0x0000000000000000000000000000000000000000'
+
+    with pytest.raises(TypeError):
+        contract.transact({'from': Owner}).setLatestVersionAddress('0x')
+    with pytest.raises(TypeError):
+        contract.transact({'from': Owner}).setLatestVersionAddress(123)
+    with pytest.raises(tester.TransactionFailed):
+        contract.transact({'from': Owner}).setLatestVersionAddress(A)
+    with pytest.raises(tester.TransactionFailed):
+        contract.transact({'from': A}).setLatestVersionAddress(other_contract.address)
+
+    contract.transact({'from': Owner}).setLatestVersionAddress(other_contract.address)
+    assert contract.call().getLatestVersionAddress() == other_contract.address
 
 
 def test_channel_223_create(web3, chain, contract, channels_contract):

--- a/contracts/tests/test_raidenchannels.py
+++ b/contracts/tests/test_raidenchannels.py
@@ -183,7 +183,7 @@ def test_version(web3, contract, channels_contract):
         contract.transact({'from': A}).setLatestVersionAddress(other_contract.address)
 
     contract.transact({'from': Owner}).setLatestVersionAddress(other_contract.address)
-    assert contract.call().getLatestVersionAddress() == other_contract.address
+    assert contract.call().latest_version_address() == other_contract.address
 
 
 def test_channel_223_create(web3, chain, contract, channels_contract):


### PR DESCRIPTION
closes #99 

- string variable for compatibility with semantic versioning
- setter & getter for latest contract version Ethereum address
- setter only callable by owner
- unit test