### PR TITLE
Increase challenge_period type size from uint8 to uint32

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -12,7 +12,7 @@ contract RaidenMicroTransferChannels {
 
     address public owner_address;
     address public token_address;
-    uint8 public challenge_period;
+    uint32 public challenge_period;
 
     // Contract semantic version
     string public constant version = '1.0.0';
@@ -94,7 +94,7 @@ contract RaidenMicroTransferChannels {
     /// @param _token_address The address of the Token used by the uRaiden contract.
     /// @param _challenge_period A fixed number of blocks representing the challenge period
     /// after a sender requests the closing of the channel without the receiver's signature.
-    function RaidenMicroTransferChannels(address _token_address, uint8 _challenge_period) public {
+    function RaidenMicroTransferChannels(address _token_address, uint32 _challenge_period) public {
         require(_token_address != 0x0);
         require(addressHasCode(_token_address));
         require(_challenge_period > 0);


### PR DESCRIPTION
`uint8` -> `max 2**8 * ~15sec / 60 = 64 min`
`uint16` -> `max 2**16 * 15 / 60 = 16384 min = 273h = 11.37 days`
`uint32` -> `max 2**16 * 15 / 60 = 45654 days`

uint8 was too small. It was chosen for decreasing gas - which is actually debatable and should be tested (EVM works with 256). Even so, you may want larger values without modifying the code.

Challenge period is anyway set at deployment, so you can make it as small as you like.

Also, it's used like this: (note block number type)
```
closing_requests[key].settle_block_number = uint32(block.number) + challenge_period;
```