### PR TITLE
Extract balance message hash logic for EIP712 in a separate contract

### DIFF
--- a/contracts/contracts/MicroRaidenEIP712Helper.sol
+++ b/contracts/contracts/MicroRaidenEIP712Helper.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.17;
 
-contract URaidenEIP712HelperContract {
+contract MicroRaidenEIP712Helper {
     /// @dev Returns the message hash used for creating the balance proof.
     /// Used in the RaidenMicroTransferChannels contract.
     /// Should be kept up-to-date with eth_signTypedData https://github.com/ethereum/EIPs/pull/712.
@@ -19,7 +19,6 @@ contract URaidenEIP712HelperContract {
         pure
         returns (bytes32)
     {
-        // Used in the RaidenMicroTransferChannels contract
         // The variable names from below will be shown to the sender when signing
         // the balance proof, so they have to be kept in sync with the Dapp client.
         // The hashed strings should be kept in sync with this function's parameters

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -24,7 +24,7 @@ contract RaidenMicroTransferChannels {
 
     // Contract implementing EIP712 helper functions.
     // Reason: EIP712 is not standardized at this moment and can have breaking changes.
-    MicoRaidenEIP712Helper public microraiden_eip712_helper;
+    MicroRaidenEIP712Helper public microraiden_eip712_helper;
 
     Token public token;
 
@@ -112,7 +112,7 @@ contract RaidenMicroTransferChannels {
     /// @param _microraiden_eip712_helper The address for EIP712 helper contract.
     function setEip712HelperContract(address _microraiden_eip712_helper) public isOwner {
         require(addressHasCode(_microraiden_eip712_helper));
-        microraiden_eip712_helper = MicoRaidenEIP712Helper(_microraiden_eip712_helper);
+        microraiden_eip712_helper = MicroRaidenEIP712Helper(_microraiden_eip712_helper);
     }
 
     /*

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -1,7 +1,8 @@
 pragma solidity ^0.4.17;
 
-import "./Token.sol";
-import "./lib/ECVerify.sol";
+import './Token.sol';
+import './lib/ECVerify.sol';
+import './URaidenEIP712HelperContract.sol';
 
 /// @title Raiden MicroTransfer Channels Contract.
 contract RaidenMicroTransferChannels {
@@ -20,6 +21,10 @@ contract RaidenMicroTransferChannels {
     // by the owner during a new contract deployment for all outdated contracts.
     // Outdated contracts can still be used.
     address public latest_version_address;
+
+    // Contract implementing EIP712 helper functions.
+    // Reason: EIP712 is not standardized at this moment and can have breaking changes.
+    URaidenEIP712HelperContract public uraiden_eip712_contract;
 
     Token public token;
 
@@ -103,6 +108,13 @@ contract RaidenMicroTransferChannels {
         latest_version_address = _latest_version_address;
     }
 
+    /// @dev Sets the address for the contract-library implementing EIP712 helper functions.
+    /// @param _uraiden_eip712_contract The address for EIP712 helper contract.
+    function setEip712HelperContract(address _uraiden_eip712_contract) public isOwner {
+        require(addressHasCode(_uraiden_eip712_contract));
+        uraiden_eip712_contract = URaidenEIP712HelperContract(_uraiden_eip712_contract);
+    }
+
     /*
      *  Public helper functions (constant)
      */
@@ -137,16 +149,15 @@ contract RaidenMicroTransferChannels {
         uint192 _balance,
         bytes _balance_msg_sig)
         public
-        constant
+        view
         returns (address)
     {
-        // The variable names from below will be shown to the sender when signing
-        // the balance proof, so they have to be kept in sync with the Dapp client.
-        // The hashed strings should be kept in sync with this function's parameters
-        // (variable names and types)
-        var message_hash = keccak256(
-          keccak256('address receiver', 'uint32 block_created', 'uint192 balance', 'address contract'),
-          keccak256(_receiver_address, _open_block_number, _balance, address(this))
+        // getMessageHash is a pure function
+        bytes32 message_hash = uraiden_eip712_contract.getMessageHash(
+            _receiver_address,
+            _open_block_number,
+            _balance,
+            address(this)
         );
 
         // Derive address from signature

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.17;
 
 import './Token.sol';
 import './lib/ECVerify.sol';
-import './URaidenEIP712HelperContract.sol';
+import './MicroRaidenEIP712Helper.sol';
 
 /// @title Raiden MicroTransfer Channels Contract.
 contract RaidenMicroTransferChannels {
@@ -24,7 +24,7 @@ contract RaidenMicroTransferChannels {
 
     // Contract implementing EIP712 helper functions.
     // Reason: EIP712 is not standardized at this moment and can have breaking changes.
-    URaidenEIP712HelperContract public uraiden_eip712_contract;
+    MicoRaidenEIP712Helper public microraiden_eip712_helper;
 
     Token public token;
 
@@ -109,10 +109,10 @@ contract RaidenMicroTransferChannels {
     }
 
     /// @dev Sets the address for the contract-library implementing EIP712 helper functions.
-    /// @param _uraiden_eip712_contract The address for EIP712 helper contract.
-    function setEip712HelperContract(address _uraiden_eip712_contract) public isOwner {
-        require(addressHasCode(_uraiden_eip712_contract));
-        uraiden_eip712_contract = URaidenEIP712HelperContract(_uraiden_eip712_contract);
+    /// @param _microraiden_eip712_helper The address for EIP712 helper contract.
+    function setEip712HelperContract(address _microraiden_eip712_helper) public isOwner {
+        require(addressHasCode(_microraiden_eip712_helper));
+        microraiden_eip712_helper = MicoRaidenEIP712Helper(_microraiden_eip712_helper);
     }
 
     /*
@@ -153,7 +153,7 @@ contract RaidenMicroTransferChannels {
         returns (address)
     {
         // getMessageHash is a pure function
-        bytes32 message_hash = uraiden_eip712_contract.getMessageHash(
+        bytes32 message_hash = microraiden_eip712_helper.getMessageHash(
             _receiver_address,
             _open_block_number,
             _balance,

--- a/contracts/contracts/URaidenEIP712HelperContract.sol
+++ b/contracts/contracts/URaidenEIP712HelperContract.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.17;
+
+contract URaidenEIP712HelperContract {
+    /// @dev Returns the message hash used for creating the balance proof.
+    /// Used in the RaidenMicroTransferChannels contract.
+    /// Should be kept up-to-date with eth_signTypedData https://github.com/ethereum/EIPs/pull/712.
+    /// @param _receiver_address The address that receives tokens.
+    /// @param _open_block_number The block number at which a channel between the
+    /// sender and receiver was created.
+    /// @param _balance The amount of tokens owed by the sender to the receiver.
+    /// @param _contract RaidenMicroTransferChannels contract address
+    /// @return Hash of the message composed from the above parameters.
+    function getMessageHash(
+        address _receiver_address,
+        uint32 _open_block_number,
+        uint192 _balance,
+        address _contract)
+        public
+        pure
+        returns (bytes32)
+    {
+        // Used in the RaidenMicroTransferChannels contract
+        // The variable names from below will be shown to the sender when signing
+        // the balance proof, so they have to be kept in sync with the Dapp client.
+        // The hashed strings should be kept in sync with this function's parameters
+        // (variable names and types)
+        bytes32 message_hash = keccak256(
+          keccak256('address receiver', 'uint32 block_created', 'uint192 balance', 'address contract'),
+          keccak256(_receiver_address, _open_block_number, _balance, _contract)
+        );
+
+        return message_hash;
+    }
+}

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -77,8 +77,8 @@ def uraiden_instance(owner, uraiden_contract, eip712_instance):
 @pytest.fixture()
 def eip712_contract(chain, create_contract):
     def get():
-        URaidenEIP712HelperContract = chain.provider.get_contract_factory('URaidenEIP712HelperContract')
-        eip712_contract = create_contract(URaidenEIP712HelperContract, [])
+        MicroRaidenEIP712Helper = chain.provider.get_contract_factory('MicroRaidenEIP712Helper')
+        eip712_contract = create_contract(MicroRaidenEIP712Helper, [])
 
         return eip712_contract
     return get

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -68,8 +68,25 @@ def uraiden_contract(contract_params, token_instance, get_uraiden_contract):
 
 
 @pytest.fixture
-def uraiden_instance(uraiden_contract):
-    return uraiden_contract()
+def uraiden_instance(owner, uraiden_contract, eip712_instance):
+    uraiden_instance = uraiden_contract()
+    uraiden_instance.transact({'from': owner}).setEip712HelperContract(eip712_instance.address)
+    return uraiden_instance
+
+
+@pytest.fixture()
+def eip712_contract(chain, create_contract):
+    def get():
+        URaidenEIP712HelperContract = chain.provider.get_contract_factory('URaidenEIP712HelperContract')
+        eip712_contract = create_contract(URaidenEIP712HelperContract, [])
+
+        return eip712_contract
+    return get
+
+
+@pytest.fixture()
+def eip712_instance(chain, eip712_contract):
+    return eip712_contract()
 
 
 @pytest.fixture(params=['20', '223'])

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -26,6 +26,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    eip712_contract,
+    eip712_instance,
     get_channel,
     channel_settle_tests,
     channel_pre_close_tests,

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -22,7 +22,9 @@ from tests.fixtures_uraiden import (
     token_instance,
     get_uraiden_contract,
     uraiden_contract,
-    uraiden_instance
+    uraiden_instance,
+    eip712_contract,
+    eip712_instance
 )
 
 

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -23,6 +23,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    eip712_contract,
+    eip712_instance,
     get_channel
 )
 from tests.fixtures_uraiden import checkToppedUpEvent

--- a/contracts/tests/test_ecverify.py
+++ b/contracts/tests/test_ecverify.py
@@ -16,7 +16,9 @@ from tests.fixtures_uraiden import (
     token_instance,
     get_uraiden_contract,
     uraiden_contract,
-    uraiden_instance
+    uraiden_instance,
+    eip712_contract,
+    eip712_instance
 )
 
 

--- a/contracts/tests/test_eip712.py
+++ b/contracts/tests/test_eip712.py
@@ -2,6 +2,7 @@ import pytest
 from ethereum import tester
 from utils import sign
 from tests.utils import balance_proof_hash
+from eth_utils import force_bytes
 from tests.fixtures import (
     owner_index,
     owner,
@@ -46,7 +47,7 @@ def test_eip712_instance(owner, get_accounts, uraiden_contract, eip712_contract,
     assert uraiden_instance.call().microraiden_eip712_helper() == eip712_instance2.address
 
 
-def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
+def test_get_message_hash(get_accounts, uraiden_instance, eip712_instance):
     (A, B) = get_accounts(2)
     receiver = '0x5601ea8445a5d96eeebf89a67c4199fbb7a43fbb'
     block = 4804175
@@ -64,8 +65,7 @@ def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
         balance,
         uraiden_instance.address
     )
-    # TODO
-    # assert eip712_message_hash == message_hash
+    assert force_bytes(eip712_message_hash) == message_hash
 
     eip712_message_hash = eip712_instance.call().getMessageHash(
         A,
@@ -73,6 +73,7 @@ def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
         balance,
         uraiden_instance.address
     )
+    assert force_bytes(eip712_message_hash) != message_hash
 
     eip712_message_hash = eip712_instance.call().getMessageHash(
         receiver,
@@ -80,7 +81,7 @@ def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
         balance,
         uraiden_instance.address
     )
-    assert eip712_message_hash != message_hash
+    assert force_bytes(eip712_message_hash) != message_hash
 
     eip712_message_hash = eip712_instance.call().getMessageHash(
         receiver,
@@ -88,7 +89,7 @@ def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
         20,
         uraiden_instance.address
     )
-    assert eip712_message_hash != message_hash
+    assert force_bytes(eip712_message_hash) != message_hash
 
     eip712_message_hash = eip712_instance.call().getMessageHash(
         receiver,
@@ -96,4 +97,4 @@ def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
         balance,
         A
     )
-    assert eip712_message_hash != message_hash
+    assert force_bytes(eip712_message_hash) != message_hash

--- a/contracts/tests/test_eip712.py
+++ b/contracts/tests/test_eip712.py
@@ -1,0 +1,99 @@
+import pytest
+from ethereum import tester
+from utils import sign
+from tests.utils import balance_proof_hash
+from tests.fixtures import (
+    owner_index,
+    owner,
+    contract_params,
+    create_contract,
+    get_token_contract,
+    get_accounts,
+    create_accounts,
+    empty_address
+)
+from tests.fixtures_uraiden import (
+    token_contract,
+    token_instance,
+    get_uraiden_contract,
+    uraiden_contract,
+    uraiden_instance,
+    eip712_contract,
+    eip712_instance
+)
+
+
+def test_eip712_instance_fixture(uraiden_instance):
+    assert uraiden_instance.call().uraiden_eip712_contract()
+
+
+def test_eip712_instance(owner, get_accounts, uraiden_contract, eip712_contract, eip712_instance):
+    uraiden_instance = uraiden_contract()
+    (A, B) = get_accounts(2)
+    assert uraiden_instance.call().uraiden_eip712_contract() == empty_address
+    uraiden_instance.transact({'from': owner}).setEip712HelperContract(eip712_instance.address)
+    assert uraiden_instance.call().uraiden_eip712_contract() == eip712_instance.address
+
+    # Test eip712_instance address change
+    eip712_instance2 = eip712_contract()
+    assert eip712_instance.address != eip712_instance2.address
+
+    # Only owner can change this
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({'from': A}).setEip712HelperContract(eip712_instance2.address)
+
+    uraiden_instance.transact({'from': owner}).setEip712HelperContract(eip712_instance2.address)
+    assert uraiden_instance.call().uraiden_eip712_contract() == eip712_instance2.address
+
+
+def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):
+    (A, B) = get_accounts(2)
+    receiver = '0x5601ea8445a5d96eeebf89a67c4199fbb7a43fbb'
+    block = 4804175
+    balance = 22000000000000000000
+
+    message_hash = sign.eth_signed_typed_data_message(
+        ('address', ('uint', 32), ('uint', 192), 'address'),
+        ('receiver', 'block_created', 'balance', 'contract'),
+        (receiver, block, balance, uraiden_instance.address)
+    )
+
+    eip712_message_hash = eip712_instance.call().getMessageHash(
+        receiver,
+        block,
+        balance,
+        uraiden_instance.address
+    )
+    # TODO
+    # assert eip712_message_hash == message_hash
+
+    eip712_message_hash = eip712_instance.call().getMessageHash(
+        A,
+        block,
+        balance,
+        uraiden_instance.address
+    )
+
+    eip712_message_hash = eip712_instance.call().getMessageHash(
+        receiver,
+        10,
+        balance,
+        uraiden_instance.address
+    )
+    assert eip712_message_hash != message_hash
+
+    eip712_message_hash = eip712_instance.call().getMessageHash(
+        receiver,
+        block,
+        20,
+        uraiden_instance.address
+    )
+    assert eip712_message_hash != message_hash
+
+    eip712_message_hash = eip712_instance.call().getMessageHash(
+        receiver,
+        block,
+        balance,
+        A
+    )
+    assert eip712_message_hash != message_hash

--- a/contracts/tests/test_eip712.py
+++ b/contracts/tests/test_eip712.py
@@ -24,15 +24,15 @@ from tests.fixtures_uraiden import (
 
 
 def test_eip712_instance_fixture(uraiden_instance):
-    assert uraiden_instance.call().uraiden_eip712_contract()
+    assert uraiden_instance.call().microraiden_eip712_helper()
 
 
 def test_eip712_instance(owner, get_accounts, uraiden_contract, eip712_contract, eip712_instance):
     uraiden_instance = uraiden_contract()
     (A, B) = get_accounts(2)
-    assert uraiden_instance.call().uraiden_eip712_contract() == empty_address
+    assert uraiden_instance.call().microraiden_eip712_helper() == empty_address
     uraiden_instance.transact({'from': owner}).setEip712HelperContract(eip712_instance.address)
-    assert uraiden_instance.call().uraiden_eip712_contract() == eip712_instance.address
+    assert uraiden_instance.call().microraiden_eip712_helper() == eip712_instance.address
 
     # Test eip712_instance address change
     eip712_instance2 = eip712_contract()
@@ -43,7 +43,7 @@ def test_eip712_instance(owner, get_accounts, uraiden_contract, eip712_contract,
         uraiden_instance.transact({'from': A}).setEip712HelperContract(eip712_instance2.address)
 
     uraiden_instance.transact({'from': owner}).setEip712HelperContract(eip712_instance2.address)
-    assert uraiden_instance.call().uraiden_eip712_contract() == eip712_instance2.address
+    assert uraiden_instance.call().microraiden_eip712_helper() == eip712_instance2.address
 
 
 def test_getMessageHash(get_accounts, uraiden_instance, eip712_instance):

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -24,6 +24,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    eip712_contract,
+    eip712_instance,
     get_channel,
     event_handler
 )


### PR DESCRIPTION
merge after https://github.com/raiden-network/microraiden/pull/198

fixes https://github.com/raiden-network/microraiden/issues/181 - you can change the balance proof message hash logic at any point.

EIP712 is not standardized and can have breaking changes.

- adds a setter in the uRaiden contract for setting the `URaidenEIP712HelperContract` address, callable only by the `RaidenMicroTransferChannels` contract owner
- exposes `getMessageHash` as a `pure` function, used in the uRaiden `verifyBalanceProof` function