### PR TITLE
Contract - add check for uint conversion

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -177,6 +177,10 @@ contract RaidenMicroTransferChannels {
     function tokenFallback(address _sender_address, uint256 _deposit, bytes _data) external {
         // Make sure we trust the token
         require(msg.sender == address(token));
+
+        uint192 deposit = uint192(_deposit);
+        require(deposit == _deposit);
+
         uint length = _data.length;
 
         // createChannel - receiver address (20 bytes)
@@ -186,14 +190,14 @@ contract RaidenMicroTransferChannels {
         address receiver = addressFromData(_data);
 
         if(length == 20) {
-            createChannelPrivate(_sender_address, receiver, uint192(_deposit));
+            createChannelPrivate(_sender_address, receiver, deposit);
         } else {
             uint32 open_block_number = blockNumberFromData(_data);
             updateInternalBalanceStructs(
                 _sender_address,
                 receiver,
                 open_block_number,
-                uint192(_deposit)
+                deposit
             );
         }
     }

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -11,19 +11,20 @@ uraiden_contract_version = '1.0.0'
 contract_args = [
     {
         'decimals': 18,
+        'supply': 10 ** 26,
         'challenge_period': 5
-    }]
-'''
+    },
     {
-        'decimals': 3,
+        'decimals': 18,
+        'supply': 2 ** 200,  # test tokenFallback uint256 -> uint192 conversion
         'challenge_period': 10
     },
     {
         'decimals': 0,
-        'challenge_period': 300
+        'supply': 10 ** 26,
+        'challenge_period': 100
     }
 ]
-'''
 
 
 uraiden_events = {

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -44,7 +44,7 @@ def get_uraiden_contract(chain, create_contract):
 @pytest.fixture()
 def token_contract(contract_params, get_token_contract):
     def get(transaction=None):
-        args = [10 ** 26, 'CustomToken', 'TKN', contract_params['decimals']]
+        args = [contract_params['supply'], 'CustomToken', 'TKN', contract_params['decimals']]
         token_contract = get_token_contract(args, transaction)
         return token_contract
     return get

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -136,7 +136,11 @@ def test_create_token_fallback_uint_conversion(contract_params, owner, get_accou
     # Open a channel with tokenFallback
     if deposit > 2 ** 192:
         with pytest.raises(tester.TransactionFailed):
-            txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, deposit, txdata)
+            txn_hash = token_instance.transact({"from": sender}).transfer(
+                uraiden_instance.address,
+                deposit,
+                txdata
+            )
     '''
     # For testing what happens in the above case if we remove the contract require(deposit == _deposit)
     open_block_number = get_block(txn_hash)

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -119,3 +119,28 @@ def test_channel_20_create(owner, get_accounts, uraiden_instance, token_instance
 
     # Create channel
     uraiden_instance.transact({"from": sender}).createChannelERC20(receiver, deposit)
+
+
+def test_create_token_fallback_uint_conversion(contract_params, owner, get_accounts, uraiden_instance, token_instance):
+    token = token_instance
+    (sender, receiver) = get_accounts(2)
+
+    # Make sure you have a fixture with a supply > 2 ** 192 + 100
+    deposit = contract_params['supply'] - 100
+    txdata = bytes.fromhex(receiver[2:].zfill(40))
+
+    # Fund accounts with tokens
+    token.transact({"from": owner}).transfer(sender, deposit)
+    assert token.call().balanceOf(sender) == deposit
+
+    # Open a channel with tokenFallback
+    if deposit > 2 ** 192:
+        with pytest.raises(tester.TransactionFailed):
+            txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, deposit, txdata)
+    '''
+    # For testing what happens in the above case if we remove the contract require(deposit == _deposit)
+    open_block_number = get_block(txn_hash)
+    assert token.call().balanceOf(uraiden_instance.address) == deposit
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[1] == deposit
+    '''

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -121,7 +121,12 @@ def test_channel_20_create(owner, get_accounts, uraiden_instance, token_instance
     uraiden_instance.transact({"from": sender}).createChannelERC20(receiver, deposit)
 
 
-def test_create_token_fallback_uint_conversion(contract_params, owner, get_accounts, uraiden_instance, token_instance):
+def test_create_token_fallback_uint_conversion(
+    contract_params,
+    owner,
+    get_accounts,
+    uraiden_instance,
+    token_instance):
     token = token_instance
     (sender, receiver) = get_accounts(2)
 
@@ -141,10 +146,3 @@ def test_create_token_fallback_uint_conversion(contract_params, owner, get_accou
                 deposit,
                 txdata
             )
-    '''
-    # For testing what happens in the above case if we remove the contract require(deposit == _deposit)
-    open_block_number = get_block(txn_hash)
-    assert token.call().balanceOf(uraiden_instance.address) == deposit
-    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    assert channel_data[1] == deposit
-    '''

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -150,3 +150,35 @@ def test_channel_topup_20(
         channel_deposit + top_up_deposit)
     )
     ev_handler.check()
+
+
+def test_topup_token_fallback_uint_conversion(contract_params, owner, get_accounts, uraiden_instance, token_instance, get_block):
+    token = token_instance
+    (sender, receiver) = get_accounts(2)
+
+    # Make sure you have a fixture with a supply > 2 ** 192
+    supply = contract_params['supply']
+    deposit = 100
+    top_up_deposit = supply - 100
+
+    txdata = bytes.fromhex(receiver[2:].zfill(40))
+
+    # Fund accounts with tokens
+    token.transact({"from": owner}).transfer(sender, supply)
+    assert token.call().balanceOf(sender) == supply
+
+    # Open a channel with tokenFallback
+    txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, deposit, txdata)
+    open_block_number = get_block(txn_hash)
+
+    assert token.call().balanceOf(uraiden_instance.address) == deposit
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[1] == deposit
+
+    top_up_data = receiver[2:].zfill(40) + hex(open_block_number)[2:].zfill(8)
+    top_up_data = bytes.fromhex(top_up_data)
+
+    # TopUp a channel with tokenFallback
+    if deposit > 2 ** 192:
+        with pytest.raises(tester.TransactionFailed):
+            txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, top_up_deposit, top_up_data)

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -152,7 +152,13 @@ def test_channel_topup_20(
     ev_handler.check()
 
 
-def test_topup_token_fallback_uint_conversion(contract_params, owner, get_accounts, uraiden_instance, token_instance, get_block):
+def test_topup_token_fallback_uint_conversion(
+    contract_params,
+    owner,
+    get_accounts,
+    uraiden_instance,
+    token_instance,
+    get_block):
     token = token_instance
     (sender, receiver) = get_accounts(2)
 

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -181,4 +181,8 @@ def test_topup_token_fallback_uint_conversion(contract_params, owner, get_accoun
     # TopUp a channel with tokenFallback
     if deposit > 2 ** 192:
         with pytest.raises(tester.TransactionFailed):
-            txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, top_up_deposit, top_up_data)
+            txn_hash = token_instance.transact({"from": sender}).transfer(
+                uraiden_instance.address,
+                top_up_deposit,
+                top_up_data
+            )


### PR DESCRIPTION
mentioned in https://github.com/raiden-network/microraiden/issues/134

`tokenFallback` converts `uint256` to `uint192`, we want to make sure transaction fails if there is an overflow.
