### PR TITLE
Add temporary bug bounty release channel deposit limit

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -15,6 +15,10 @@ contract RaidenMicroTransferChannels {
     // Contract semantic version
     string public constant version = '0.1.0';
 
+    // We temporarily limit total token deposits in a channel to 100 tokens with 18 decimals.
+    // This is just for the bug bounty release.
+    uint256 public channel_deposit_bugbounty_limit = 10 ** 18 * 100;
+
     Token public token;
 
     mapping (bytes32 => Channel) public channels;
@@ -310,6 +314,8 @@ contract RaidenMicroTransferChannels {
     /// @param _receiver_address The address that receives tokens.
     /// @param _deposit The amount of tokens that the sender escrows.
     function createChannelPrivate(address _sender_address, address _receiver_address, uint192 _deposit) private {
+        require(_deposit <= channel_deposit_bugbounty_limit);
+
         uint32 open_block_number = uint32(block.number);
 
         // Create unique identifier from sender, receiver and current block number
@@ -344,6 +350,7 @@ contract RaidenMicroTransferChannels {
 
         require(channels[key].deposit > 0);
         require(closing_requests[key].settle_block_number == 0);
+        require(channels[key].deposit + _added_deposit <= channel_deposit_bugbounty_limit);
 
         channels[key].deposit += _added_deposit;
         assert(channels[key].deposit > _added_deposit);

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -16,8 +16,10 @@ contract RaidenMicroTransferChannels {
     string public constant version = '0.1.0';
 
     // We temporarily limit total token deposits in a channel to 100 tokens with 18 decimals.
-    // This is just for the bug bounty release.
-    uint256 public channel_deposit_bugbounty_limit = 10 ** 18 * 100;
+    // This was calculated just for RDN with its current (as of 30/11/2017) price and should
+    // not be considered to be the same for other tokens.
+    // This is just for the bug bounty release, as a safety measure.
+    uint256 public constant channel_deposit_bugbounty_limit = 10 ** 18 * 100;
 
     Token public token;
 

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -8,6 +8,7 @@ fake_address = '0x03432'
 empty_address = '0x0000000000000000000000000000000000000000'
 passphrase = '0'
 uraiden_contract_version = '0.1.0'
+channel_deposit_bugbounty_limit = 100 * 10 ** 18
 contract_args = [
     {
         'decimals': 18,

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from ethereum import tester
 from tests.fixtures import (
+    channel_deposit_bugbounty_limit,
     uraiden_contract_version,
     contract_params,
     owner_index,
@@ -63,12 +64,16 @@ def test_uraiden_init(
     assert token.call().balanceOf(uraiden.address) == 0
     assert web3.eth.getBalance(uraiden.address) == 0
 
+    # Temporary limit for the bug bounty release
+    assert uraiden.call().channel_deposit_bugbounty_limit() == channel_deposit_bugbounty_limit
+
 
 def test_variable_access(owner, uraiden_contract, token_instance, contract_params):
-    uraiden_instance = uraiden_contract()
-    assert uraiden_instance.call().token() == token_instance.address
-    assert uraiden_instance.call().challenge_period() == contract_params['challenge_period']
-    assert uraiden_instance.call().version() == uraiden_contract_version
+    uraiden = uraiden_contract()
+    assert uraiden.call().token() == token_instance.address
+    assert uraiden.call().challenge_period() == contract_params['challenge_period']
+    assert uraiden.call().version() == uraiden_contract_version
+    assert uraiden.call().channel_deposit_bugbounty_limit() == channel_deposit_bugbounty_limit
 
 
 def test_function_access(


### PR DESCRIPTION
Limit token deposits for the bug bounty Mainnet release.

Thought about taking token.decimals() into consideration, but decided to go with the simple solution. This function is not a requirement for erc20. Additionally, the scope is to preventively limit loss - hard to calculate for other tokens.