### PR TITLE
Fix topup event argument names

### DIFF
--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -160,7 +160,7 @@ class Client:
 
         for e in topup:
             c = get_channel(e)
-            c.deposit = e['args']['_deposit']
+            c.deposit += e['args']['_added_deposit']
 
         for e in close:
             # Requested closed, not actual closed.


### PR DESCRIPTION
The argument name for a top up event `_deposit` changed to `_added_deposit`.