### PR TITLE
Allow retry on invalid amount

### DIFF
--- a/microraiden/microraiden/client/default_http_client.py
+++ b/microraiden/microraiden/client/default_http_client.py
@@ -53,7 +53,7 @@ class DefaultHTTPClient(HTTPClient):
         log.error(
             'Server was unable to verify the transfer - Invalid amount sent by the client.'
         )
-        return False
+        return True
 
     def _approve_payment(self, balance: int, balance_sig: bytes, channel_manager_address: str):
         assert balance is None or isinstance(balance, int)


### PR DESCRIPTION
If the client is out of sync with the server and receives payment headers with `Rdn-Invalid-Amount` set, it should retry the request with an updated balance.