### PR TITLE
Handle case where channel manager has no eth left

### DIFF
--- a/microraiden/microraiden/channel_manager/__init__.py
+++ b/microraiden/microraiden/channel_manager/__init__.py
@@ -1,11 +1,12 @@
 from .manager import ChannelManager
 from .blockchain import Blockchain
 from .state import ChannelManagerState
-from .channel import Channel
+from .channel import Channel, ChannelState
 
 __all__ = [
     ChannelManager,
     Blockchain,
     ChannelManagerState,
-    Channel
+    Channel,
+    ChannelState
 ]

--- a/microraiden/microraiden/channel_manager/channel.py
+++ b/microraiden/microraiden/channel_manager/channel.py
@@ -1,4 +1,12 @@
 import time
+from enum import IntEnum
+
+
+class ChannelState(IntEnum):
+    OPEN = 0
+    CLOSED = 1
+    CLOSE_PENDING = 2
+    UNDEFINED = 100
 
 
 class Channel(object):
@@ -11,7 +19,7 @@ class Channel(object):
         self.open_block_number = open_block_number
 
         self.balance = 0  # how much of the deposit has been spent
-        self.is_closed = False
+        self.state = ChannelState.UNDEFINED
         self.last_signature = None
         # if set, this is the absolute block_number the channel can be settled
         self.settle_timeout = -1
@@ -20,6 +28,15 @@ class Channel(object):
         self.confirmed = False
 
         self.unconfirmed_topups = {}  # txhash to added deposit
+
+    @property
+    def is_closed(self):
+        return (self.state) in (ChannelState.CLOSED, ChannelState.CLOSE_PENDING)
+
+    @is_closed.setter
+    def is_closed(self, value):
+        assert value is True
+        self.state = ChannelState.CLOSED
 
     @property
     def unconfirmed_deposit(self):

--- a/microraiden/microraiden/channel_manager/manager.py
+++ b/microraiden/microraiden/channel_manager/manager.py
@@ -9,6 +9,7 @@ from eth_utils import (
     decode_hex,
     is_same_address
 )
+from ethereum.exceptions import InsufficientBalance
 
 from microraiden.crypto import (
     verify_balance_proof,
@@ -30,7 +31,7 @@ from microraiden.exceptions import (
 from microraiden.config import CHANNEL_MANAGER_CONTRACT_VERSION
 from .state import ChannelManagerState
 from .blockchain import Blockchain
-from .channel import Channel
+from .channel import Channel, ChannelState
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +115,7 @@ class ChannelManager(gevent.Greenlet):
             return  # ignore event if already provessed
         c = Channel(self.state.receiver, sender, deposit, open_block_number)
         c.confirmed = True
+        c.state = ChannelState.OPEN
         self.log.info('new channel opened (sender %s, block number %s)', sender, open_block_number)
         self.state.set_channel(c)
 
@@ -125,6 +127,7 @@ class ChannelManager(gevent.Greenlet):
             return
         c = Channel(self.state.receiver, sender, deposit, open_block_number)
         c.confirmed = False
+        c.state = ChannelState.OPEN
         self.state.set_channel(c)
         self.log.info('unconfirmed channel event received (sender %s, block_number %s)',
                       sender, open_block_number)
@@ -141,8 +144,9 @@ class ChannelManager(gevent.Greenlet):
             return
         c = self.channels[sender, open_block_number]
         if c.balance > balance:
-            self.log.info('sender tried to cheat, sending challenge (sender %s, block number %s)',
-                          sender, open_block_number)
+            self.log.warning('sender tried to cheat, sending challenge '
+                             '(sender %s, block number %s)',
+                             sender, open_block_number)
             self.close_channel(sender, open_block_number)  # dispute by closing the channel
         else:
             self.log.info('valid channel close request received '
@@ -214,13 +218,19 @@ class ChannelManager(gevent.Greenlet):
                      c.balance, decode_hex(c.last_signature)]
         raw_tx = self.contract_proxy.create_signed_transaction('uncooperativeClose', tx_params)
 
-        txid = self.blockchain.web3.eth.sendRawTransaction(raw_tx)
-        self.log.info('sent channel close(sender %s, block number %s, tx %s)',
-                      sender, open_block_number, txid)
         # update local state
         c.is_closed = True
         c.mtime = time.time()
         self.state.set_channel(c)
+
+        try:
+            txid = self.blockchain.web3.eth.sendRawTransaction(raw_tx)
+            self.log.info('sent channel close(sender %s, block number %s, tx %s)',
+                          sender, open_block_number, txid)
+        except InsufficientBalance:
+            c.state = ChannelState.CLOSE_PENDING
+            self.state.set_channel(c)
+            raise
 
     def force_close_channel(self, sender, open_block_number):
         """Forcibly remove a channel from our channel state"""
@@ -261,6 +271,10 @@ class ChannelManager(gevent.Greenlet):
         """Get the balance of the receiver in the token contract (not locked in channels)."""
         balance = self.token_contract.call().balanceOf(self.receiver)
         return balance
+
+    def get_eth_balance(self):
+        """Get eth balance of the receiver"""
+        return self.contract_proxy.web3.eth.getBalance(self.receiver)
 
     def verify_balance_proof(self, sender, open_block_number, balance, signature):
         """Verify that a balance proof is valid and return the sender.
@@ -327,6 +341,10 @@ class ChannelManager(gevent.Greenlet):
     def unconfirmed_channels(self):
         return self.state.unconfirmed_channels
 
+    @property
+    def pending_channels(self):
+        return self.state.pending_channels
+
     def channels_to_dict(self):
         """Export all channels as a dictionary."""
         d = {}
@@ -375,3 +393,10 @@ class ChannelManager(gevent.Greenlet):
             raise InvalidContractVersion("Incompatible contract version: expected=%s deployed=%s" %
                                          (CHANNEL_MANAGER_CONTRACT_VERSION,
                                           deployed_contract_version))
+
+    def close_pending_channels(self):
+        """Close all channels that are in CLOSE_PENDING state.
+        This state happens if the receiver's eth balance is not enough to
+            close channel on-chain."""
+        for sender, open_block_number in self.pending_channels.keys():
+            self.close_channel(sender, open_block_number)  # dispute by closing the channel

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -45,3 +45,10 @@ with open(os.path.join(MICRORAIDEN_DIR, 'microraiden', CONTRACTS_ABI_JSON)) as m
 # required version of the deployed contract at CHANNEL_MANAGER_ADDRESS.
 # Proxy will refuse to start if the versions do not match.
 CHANNEL_MANAGER_CONTRACT_VERSION = "1.0.0"
+#  proxy will stop serving requests if receiver balance is below PROXY_BALANCE_LIMIT
+PROXY_BALANCE_LIMIT = 10**6
+
+
+# sanity checks
+assert PROXY_BALANCE_LIMIT > 0
+assert isinstance(PROXY_BALANCE_LIMIT, int)

--- a/microraiden/microraiden/contract_proxy.py
+++ b/microraiden/microraiden/contract_proxy.py
@@ -5,7 +5,6 @@ from ethereum.transactions import Transaction
 from web3 import Web3
 from web3.exceptions import BadFunctionCallOutput
 from web3.formatters import input_filter_params_formatter, log_array_formatter
-from web3.utils.empty import empty as web3_empty
 from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
 
@@ -21,8 +20,6 @@ class ContractProxy:
         self.web3 = web3
         self.privkey = privkey
         self.caller_address = privkey_to_addr(privkey)
-        if self.web3.eth.defaultAccount == web3_empty:
-            self.web3.eth.defaultAccount = self.caller_address
         self.address = contract_address
         self.abi = abi
         self.contract = self.web3.eth.contract(abi=self.abi, address=contract_address)

--- a/microraiden/microraiden/proxy/paywalled_proxy.py
+++ b/microraiden/microraiden/proxy/paywalled_proxy.py
@@ -40,6 +40,9 @@ class PaywalledProxy:
                  flask_app=None,
                  paywall_html_dir=None,
                  paywall_js_dir=None):
+        #  this doesn't work atm, due to test teardown problems
+        #  it's not a critical error, but it should be fixed
+        #  gevent.get_hub().SYSTEM_ERROR += (BaseException, )
         paywall_html_dir = paywall_html_dir or config.HTML_DIR
         paywall_js_dir = paywall_js_dir or config.JSLIB_DIR
         assert isinstance(channel_manager, ChannelManager)
@@ -137,6 +140,7 @@ class PaywalledProxy:
     @staticmethod
     def gevent_error_handler(context, exc_info):
         e = exc_info[1]
+        # recover if HTTP request is done to a HTTPS endpoint
         if isinstance(e, ssl.SSLError) and e.reason == 'HTTP_REQUEST':
             return
         gevent.get_hub().handle_system_error(exc_info[0], exc_info[1])

--- a/microraiden/microraiden/proxy/resources/expensive.py
+++ b/microraiden/microraiden/proxy/resources/expensive.py
@@ -114,6 +114,8 @@ class Expensive(Resource):
         log.info(content)
         if self.channel_manager.node_online() is False:
             return "Ethereum node is not responding", 502
+        if self.channel_manager.get_eth_balance() < config.PROXY_BALANCE_LIMIT:
+            return "Channel manager ETH balance is below limit", 502
         try:
             data = RequestData(request.headers, request.cookies)
         except ValueError as e:

--- a/microraiden/microraiden/test/fixtures/http_client.py
+++ b/microraiden/microraiden/test/fixtures/http_client.py
@@ -17,4 +17,4 @@ def default_http_client(client, api_endpoint, api_endpoint_port):
 
     http_client = DefaultHTTPClient(client, api_endpoint, api_endpoint_port, retry_interval=0.5)
     http_client._request_resource = types.MethodType(request_patched, http_client)
-    return http_client
+    yield http_client

--- a/microraiden/microraiden/test/test_broke_proxy.py
+++ b/microraiden/microraiden/test/test_broke_proxy.py
@@ -1,0 +1,33 @@
+from microraiden import DefaultHTTPClient
+from microraiden.test.utils.client import patch_on_http_response
+
+from microraiden.test.config import (
+    FAUCET_ADDRESS,
+)
+
+
+#  @pytest.mark.skip(reason="waiting for client to return status code")
+def test_cheating_client(
+        doggo_proxy,
+        web3,
+        default_http_client: DefaultHTTPClient,
+        wait_for_blocks
+):
+    patch_on_http_response(default_http_client, abort_on=[502])
+    balance = web3.eth.getBalance(doggo_proxy.channel_manager.receiver)
+    assert balance > 0
+    # remove all receiver's eth
+    web3.eth.sendTransaction({'from': doggo_proxy.channel_manager.receiver,
+                              'to': FAUCET_ADDRESS,
+                              'value': balance - 90000})
+    wait_for_blocks(1)
+    default_http_client.run('doggo.jpg')
+    # proxy is expected to return 502 - it has no funds
+    assert default_http_client.last_response.status_code == 502
+    web3.eth.sendTransaction({'from': FAUCET_ADDRESS,
+                              'to': doggo_proxy.channel_manager.receiver,
+                              'value': balance})
+    wait_for_blocks(1)
+    default_http_client.run('doggo.jpg')
+    # now it should proceed normally
+    assert default_http_client.last_response.status_code == 200

--- a/microraiden/microraiden/test/test_channel_manager_db.py
+++ b/microraiden/microraiden/test/test_channel_manager_db.py
@@ -1,6 +1,7 @@
 import pytest
 from microraiden.channel_manager import (
     Channel,
+    ChannelState,
     ChannelManagerState
 )
 
@@ -66,6 +67,7 @@ def test_sync_state(state):
 def test_adding_channel(state):
     channel = Channel(RECEIVER_ADDRESS, SENDER_ADDRESS, 100, 123)
     channel.balance = 50
+    channel.state = ChannelState.OPEN
     assert not state.channel_exists(channel.sender, channel.open_block_number)
     state.add_channel(channel)
     assert state.channel_exists(channel.sender, channel.open_block_number)
@@ -84,6 +86,7 @@ def test_adding_channel(state):
 def test_updating_channel(state):
     channel = Channel(RECEIVER_ADDRESS, SENDER_ADDRESS, 100, 123)
     channel.balance = 50
+    channel.state = ChannelState.OPEN
     state.add_channel(channel)
     channel.deposit = 200
     channel.balance = 100


### PR DESCRIPTION
If channel manager ether balance is too low, it can't dispute unhonest channel closes. This fix will add recover scenario for such situation.
In short, if channel can't be closed, its state will become `CLOSE_PENDING` and channel manager will attempt to close it again as soon as its ether balance is above the set limit.

Fixes #238 