### PR TITLE
Add contract version check

### DIFF
--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -19,15 +19,29 @@ NETWORK_NAMES = {
     1337: 'geth'
 }
 
+# address of the default channel manager contract. You can change this using commandline
+# option --channel-manager-address when running the proxy
 CHANNEL_MANAGER_ADDRESS = '0xeb8f0c65921c6f2b6025d9dbdd9466419cbe56ec'
+# absolute path to this directory. Used to find path to the webUI sources
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# webUI sources
 HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
+# javascript library for microraiden
 JSLIB_DIR = os.path.join(HTML_DIR, 'js')
+# decimals of the token. Any price that's set for the proxy resources is multiplied by this.
 TKN_DECIMALS = 10**18  # token decimals
 
+# ethereum node RPC interface should be available here
 WEB3_PROVIDER_DEFAULT = "http://127.0.0.1:8545"
 
+# name of the token contract
 TOKEN_ABI_NAME = 'CustomToken'
+# compiled contracts path
 CONTRACTS_ABI_JSON = 'data/contracts.json'
+
 with open(os.path.join(MICRORAIDEN_DIR, 'microraiden', CONTRACTS_ABI_JSON)) as metadata_file:
     CONTRACT_METADATA = json.load(metadata_file)
+
+# required version of the deployed contract at CHANNEL_MANAGER_ADDRESS.
+# Proxy will refuse to start if the versions do not match.
+CHANNEL_MANAGER_CONTRACT_VERSION = "1.0.0"

--- a/microraiden/microraiden/exceptions.py
+++ b/microraiden/microraiden/exceptions.py
@@ -26,6 +26,10 @@ class StateFileException(MicroRaidenException):
     pass
 
 
+class InvalidContractVersion(MicroRaidenException):
+    pass
+
+
 class StateContractAddrMismatch(StateFileException):
     pass
 

--- a/microraiden/microraiden/test/test_version.py
+++ b/microraiden/microraiden/test/test_version.py
@@ -1,0 +1,55 @@
+import pytest
+from microraiden.test.config import (
+    RECEIVER_ETH_ALLOWANCE,
+    RECEIVER_TOKEN_ALLOWANCE
+)
+from microraiden.channel_manager import ChannelManager
+from microraiden.exceptions import InvalidContractVersion
+from microraiden.crypto import privkey_to_addr
+
+
+class FakeChannelManagerContract:
+    def __init__(self, receiver1_privkey):
+        self._address = privkey_to_addr(receiver1_privkey)
+
+    def call(self):
+        # forgive me God for I have sinned here
+        return self
+
+    def version(self):
+        return "6.6.6"
+
+    @property
+    def address(self):
+        return self._address
+
+
+def test_version(web3,
+                 make_channel_manager_proxy,
+                 token_contract,
+                 make_account):
+    """Test if proxy refuses to run if it deployed contract version
+    is different from the one it expects"""
+    receiver1_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
+    channel_manager_contract = make_channel_manager_proxy(receiver1_privkey)
+
+    # this one should not raise
+    ChannelManager(
+        web3,
+        channel_manager_contract,
+        token_contract,
+        receiver1_privkey,
+        state_filename=":memory:"
+    )
+    # now we patch it
+    channel_manager_contract.contract = FakeChannelManagerContract(receiver1_privkey)
+
+    # check of version string should fail here
+    with pytest.raises(InvalidContractVersion):
+        ChannelManager(
+            web3,
+            channel_manager_contract,
+            token_contract,
+            receiver1_privkey,
+            state_filename=":memory:"
+        )


### PR DESCRIPTION
The version check is done in the ChannelManager class and will
raise InvalidContractVersion exception on failed check.
Right now only a dumb comparison is done - in future minor version
changes of the contract will probably be backward-compatible.


Fixes #214