### PR TITLE
Contract closing signature

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -213,6 +213,7 @@ contract RaidenMicroTransferChannels {
     {
         bytes32 key = getKey(msg.sender, _receiver_address, _open_block_number);
 
+        require(channels[key].open_block_number > 0);
         require(closing_requests[key].settle_block_number == 0);
         require(_balance <= channels[key].deposit);
 

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -298,7 +298,7 @@ contract RaidenMicroTransferChannels {
         // new contract deployment with updated code.
         bytes32 message_hash = keccak256(
             keccak256(
-                'string messageID',
+                'string message_id',
                 'address receiver',
                 'uint32 block_created',
                 'uint192 balance',
@@ -343,7 +343,7 @@ contract RaidenMicroTransferChannels {
         // new contract deployment with updated code.
         bytes32 message_hash = keccak256(
             keccak256(
-                'string messageID',
+                'string message_id',
                 'address sender',
                 'uint32 block_created',
                 'uint192 balance',

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -189,10 +189,10 @@ contract RaidenMicroTransferChannels {
         external
     {
         // Derive sender address from signed balance proof
-        address sender = verifyBalanceProof(_receiver_address, _open_block_number, _balance, _balance_msg_sig);
+        address sender = extractBalanceProofSignature(_receiver_address, _open_block_number, _balance, _balance_msg_sig);
 
         // Derive receiver address from closing signature
-        address receiver = verifyClosingSignature(sender, _open_block_number, _balance, _closing_sig);
+        address receiver = extractClosingSignature(sender, _open_block_number, _balance, _closing_sig);
         require(receiver == _receiver_address);
 
         // Both signatures have been verified and the channel can be settled.
@@ -281,7 +281,7 @@ contract RaidenMicroTransferChannels {
     /// @param _balance The amount of tokens owed by the sender to the receiver.
     /// @param _balance_msg_sig The balance message signed by the sender.
     /// @return Address of the balance proof signer.
-    function verifyBalanceProof(
+    function extractBalanceProofSignature(
         address _receiver_address,
         uint32 _open_block_number,
         uint192 _balance,
@@ -326,7 +326,7 @@ contract RaidenMicroTransferChannels {
     /// @param _balance The amount of tokens owed by the sender to the receiver.
     /// @param _closing_sig The receiver's signed balance message, containing the sender's address.
     /// @return Address of the closing signature signer.
-    function verifyClosingSignature(
+    function extractClosingSignature(
         address _sender_address,
         uint32 _open_block_number,
         uint192 _balance,

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -172,38 +172,14 @@ contract RaidenMicroTransferChannels {
         require(token.transferFrom(msg.sender, address(this), _added_deposit));
     }
 
-    /// @notice Function called when any of the parties wants to close the channel and settle.
-    /// Receiver needs a balance proof to immediately settle, sender triggers a challenge period.
+    /// @notice Function called by the sender, receiver or a delegate, with all the needed
+    /// signatures to close the channel and settle immediately.
     /// @param _receiver_address The address that receives tokens.
     /// @param _open_block_number The block number at which a channel between the
     /// sender and receiver was created.
     /// @param _balance The amount of tokens owed by the sender to the receiver.
     /// @param _balance_msg_sig The balance message signed by the sender.
-    function uncooperativeClose(
-        address _receiver_address,
-        uint32 _open_block_number,
-        uint192 _balance,
-        bytes _balance_msg_sig)
-        external
-    {
-        address sender = verifyBalanceProof(_receiver_address, _open_block_number, _balance, _balance_msg_sig);
-
-        if(msg.sender == _receiver_address) {
-            settleChannel(sender, _receiver_address, _open_block_number, _balance);
-        } else {
-            require(msg.sender == sender);
-            initChallengePeriod(_receiver_address, _open_block_number, _balance);
-        }
-    }
-
-    /// @notice Function called by the sender, when he has a closing signature from the receiver
-    /// and channel is closed immediately.
-    /// @param _receiver_address The address that receives tokens.
-    /// @param _open_block_number The block number at which a channel between the
-    /// sender and receiver was created.
-    /// @param _balance The amount of tokens owed by the sender to the receiver.
-    /// @param _balance_msg_sig The balance message signed by the sender.
-    /// @param _closing_sig The hash of the signed balance message, signed by the receiver.
+    /// @param _closing_sig The receiver's signed balance message, containing the sender's address.
     function cooperativeClose(
         address _receiver_address,
         uint32 _open_block_number,
@@ -212,16 +188,41 @@ contract RaidenMicroTransferChannels {
         bytes _closing_sig)
         external
     {
-        // Derive receiver address from signature
-        address receiver = ECVerify.ecverify(keccak256(_balance_msg_sig), _closing_sig);
-        require(receiver == _receiver_address);
-
         // Derive sender address from signed balance proof
         address sender = verifyBalanceProof(_receiver_address, _open_block_number, _balance, _balance_msg_sig);
-        require(msg.sender == sender);
 
+        // Derive receiver address from closing signature
+        address receiver = verifyClosingSignature(sender, _open_block_number, _balance, _closing_sig);
+        require(receiver == _receiver_address);
+
+        // Both signatures have been verified and the channel can be settled.
         settleChannel(sender, receiver, _open_block_number, _balance);
     }
+
+    /// @notice Sender requests the closing of the channel and starts the challenge period.
+    /// This can only happen once.
+    /// @param _receiver_address The address that receives tokens.
+    /// @param _open_block_number The block number at which a channel between
+    /// the sender and receiver was created.
+    /// @param _balance The amount of tokens owed by the sender to the receiver.
+    function uncooperativeClose(
+        address _receiver_address,
+        uint32 _open_block_number,
+        uint192 _balance)
+        external
+    {
+        bytes32 key = getKey(msg.sender, _receiver_address, _open_block_number);
+
+        require(closing_requests[key].settle_block_number == 0);
+        require(_balance <= channels[key].deposit);
+
+        // Mark channel as closed
+        closing_requests[key].settle_block_number = uint32(block.number) + challenge_period;
+        require(closing_requests[key].settle_block_number > block.number);
+        closing_requests[key].closing_balance = _balance;
+        ChannelCloseRequested(msg.sender, _receiver_address, _open_block_number, _balance);
+    }
+
 
     /// @notice Function called by the sender after the challenge period has ended, in order to
     /// settle and delete the channel, in case the receiver has not closed the channel himself.
@@ -304,6 +305,39 @@ contract RaidenMicroTransferChannels {
         return signer;
     }
 
+    /// @dev Returns the receiver address extracted from the closing signature.
+    /// Works with eth_signTypedData https://github.com/ethereum/EIPs/pull/712.
+    /// @param _sender_address The address that sends tokens.
+    /// @param _open_block_number The block number at which a channel between the
+    /// sender and receiver was created.
+    /// @param _balance The amount of tokens owed by the sender to the receiver.
+    /// @param _closing_sig The receiver's signed balance message, containing the sender's address.
+    /// @return Address of the closing signature signer.
+    function verifyClosingSignature(
+        address _sender_address,
+        uint32 _open_block_number,
+        uint192 _balance,
+        bytes _closing_sig)
+        public
+        view
+        returns (address)
+    {
+        // The variable names from below will be shown to the sender when signing
+        // the balance proof, so they have to be kept in sync with the Dapp client.
+        // The hashed strings should be kept in sync with this function's parameters
+        // (variable names and types).
+        // ! Note that EIP712 might change how hashing is done, triggering a
+        // new contract deployment with updated code.
+        bytes32 message_hash = keccak256(
+          keccak256('address sender', 'uint32 block_created', 'uint192 balance', 'address contract'),
+          keccak256(_sender_address, _open_block_number, _balance, address(this))
+        );
+
+        // Derive address from signature
+        address signer = ECVerify.ecverify(message_hash, _closing_sig);
+        return signer;
+    }
+
     /// @notice Returns the unique channel identifier used in the contract.
     /// @param _sender_address The address that sends tokens.
     /// @param _receiver_address The address that receives tokens.
@@ -371,30 +405,6 @@ contract RaidenMicroTransferChannels {
         channels[key].deposit += _added_deposit;
         assert(channels[key].deposit > _added_deposit);
         ChannelToppedUp(_sender_address, _receiver_address, _open_block_number, _added_deposit);
-    }
-
-
-    /// @dev Sender starts the challenge period; this can only happen once.
-    /// @param _receiver_address The address that receives tokens.
-    /// @param _open_block_number The block number at which a channel between
-    /// the sender and receiver was created.
-    /// @param _balance The amount of tokens owed by the sender to the receiver.
-    function initChallengePeriod(
-        address _receiver_address,
-        uint32 _open_block_number,
-        uint192 _balance)
-        private
-    {
-        bytes32 key = getKey(msg.sender, _receiver_address, _open_block_number);
-
-        require(closing_requests[key].settle_block_number == 0);
-        require(_balance <= channels[key].deposit);
-
-        // Mark channel as closed
-        closing_requests[key].settle_block_number = uint32(block.number) + challenge_period;
-        require(closing_requests[key].settle_block_number > block.number);
-        closing_requests[key].closing_balance = _balance;
-        ChannelCloseRequested(msg.sender, _receiver_address, _open_block_number, _balance);
     }
 
     /// @dev Deletes the channel and settles by transfering the balance to the receiver

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -297,8 +297,20 @@ contract RaidenMicroTransferChannels {
         // ! Note that EIP712 might change how hashing is done, triggering a
         // new contract deployment with updated code.
         bytes32 message_hash = keccak256(
-          keccak256('address receiver', 'uint32 block_created', 'uint192 balance', 'address contract'),
-          keccak256(_receiver_address, _open_block_number, _balance, address(this))
+            keccak256(
+                'string messageID',
+                'address receiver',
+                'uint32 block_created',
+                'uint192 balance',
+                'address contract'
+            ),
+            keccak256(
+                'Sender balance proof signature',
+                _receiver_address,
+                _open_block_number,
+                _balance,
+                address(this)
+            )
         );
 
         // Derive address from signature
@@ -330,8 +342,20 @@ contract RaidenMicroTransferChannels {
         // ! Note that EIP712 might change how hashing is done, triggering a
         // new contract deployment with updated code.
         bytes32 message_hash = keccak256(
-          keccak256('address sender', 'uint32 block_created', 'uint192 balance', 'address contract'),
-          keccak256(_sender_address, _open_block_number, _balance, address(this))
+            keccak256(
+                'string messageID',
+                'address sender',
+                'uint32 block_created',
+                'uint192 balance',
+                'address contract'
+            ),
+            keccak256(
+                'Receiver closing signature',
+                _sender_address,
+                _open_block_number,
+                _balance,
+                address(this)
+            )
         );
 
         // Derive address from signature

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -68,7 +68,6 @@ def channel_params(request):
     return request.param
 
 
-
 @pytest.fixture()
 def owner_index():
     return 1

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -5,7 +5,7 @@ from utils.logs import LogHandler
 print_the_logs = False
 
 
-MAX_UINT = 2 ** 256 - 1
+MAX_UINT256 = 2 ** 256 - 1
 MAX_UINT192 = 2 ** 192 - 1
 MAX_UINT32 = 2 ** 32 - 1
 fake_address = '0x03432'

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -2,8 +2,12 @@ import pytest
 from utils.logs import LogHandler
 
 
+print_the_logs = False
+
+
 MAX_UINT = 2 ** 256 - 1
 MAX_UINT192 = 2 ** 192 - 1
+MAX_UINT32 = 2 ** 32 - 1
 fake_address = '0x03432'
 empty_address = '0x0000000000000000000000000000000000000000'
 passphrase = '0'
@@ -27,6 +31,23 @@ contract_args = [
         'challenge_period': 502
     }
 ]
+channel_values = [
+    {
+        'deposit': 450,
+        'balance': 0,
+        'type': '20'
+    },
+    {
+        'deposit': 100 * 10 ** 18,
+        'balance': 55 * 10 ** 18,
+        'type': '223'
+    },
+    {
+        'deposit': 100 * 10 ** 18,
+        'balance': 100 * 10 ** 18,
+        'type': '223'
+    }
+]
 
 
 uraiden_events = {
@@ -42,6 +63,12 @@ def contract_params(request):
     return request.param
 
 
+@pytest.fixture(params=channel_values)
+def channel_params(request):
+    return request.param
+
+
+
 @pytest.fixture()
 def owner_index():
     return 1
@@ -54,8 +81,9 @@ def owner(web3, owner_index):
 
 @pytest.fixture()
 def get_accounts(web3, owner_index, create_accounts):
-    def get(number):
-        index_start = owner_index + 1
+    def get(number, index_start=None):
+        if not index_start:
+            index_start = owner_index + 1
         accounts_len = len(web3.eth.accounts)
         index_end = min(number + index_start, accounts_len)
         accounts = web3.eth.accounts[index_start:index_end]

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -2,7 +2,6 @@ import pytest
 from ethereum import tester
 from utils import sign
 from tests.utils import balance_proof_hash, closing_message_hash
-from utils.utils import sol_sha3
 from tests.fixtures import (
     contract_params,
     channel_params,
@@ -41,67 +40,149 @@ def test_uncooperative_close_call(channel_params, uraiden_instance, get_channel)
     balance = channel_params['balance']
 
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(0x0, open_block_number, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            0x0,
+            open_block_number,
+            balance
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(fake_address, open_block_number, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            fake_address,
+            open_block_number,
+            balance
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, -2, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            -2,
+            balance
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, MAX_UINT32 + 1, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            MAX_UINT32 + 1,
+            balance
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, -2)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            -2
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, MAX_UINT + 1)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            MAX_UINT + 1
+        )
 
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
 
-def test_uncooperative_close_fail_no_channel(channel_params, get_accounts, uraiden_instance, get_channel):
+def test_uncooperative_close_fail_no_channel(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
     A = get_accounts(1, 5)[0]
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     # Should fail if called by anyone else than the sender
-    #with pytest.raises(tester.TransactionFailed):
-    #    uraiden_instance.transact({"from": receiver}).uncooperativeClose(receiver, open_block_number, balance)
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": A}).uncooperativeClose(receiver, open_block_number, balance)
+        uraiden_instance.transact({"from": receiver}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            balance
+        )
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": A}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            balance
+        )
 
     # Should fail if the channel does not exist
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(A, open_block_number, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            A,
+            open_block_number,
+            balance
+        )
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number - 1, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number - 1,
+            balance
+        )
 
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
 
-def test_uncooperative_close_fail_big_balance(channel_params, get_accounts, uraiden_instance, token_instance, get_channel):
+def test_uncooperative_close_fail_big_balance(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
-    balance = channel_params['balance']
     deposit = channel_params['deposit']
 
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, deposit + 1)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            deposit + 1
+        )
 
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, deposit)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        deposit
+    )
 
 
-def test_uncooperative_close_fail_in_challenge_period(channel_params, get_accounts, uraiden_instance, token_instance, get_channel):
+def test_uncooperative_close_fail_in_challenge_period(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     # Should fail if the channel is already in a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
     channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
     assert channel_info[2] > 0  # settle_block_number
 
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            balance
+        )
 
 
-def test_uncooperative_close_fail_uint32_overflow(web3, channel_params, get_uraiden_contract, token_instance, get_channel):
+def test_uncooperative_close_fail_uint32_overflow(
+        web3,
+        channel_params,
+        get_uraiden_contract,
+        token_instance,
+        get_channel):
     challenge_period = MAX_UINT32 - 20
     uraiden_instance = get_uraiden_contract(
         [token_instance.address, challenge_period]
@@ -115,10 +196,19 @@ def test_uncooperative_close_fail_uint32_overflow(web3, channel_params, get_urai
     assert web3.eth.getBlock('latest')['number'] + challenge_period == MAX_UINT32
 
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+        uraiden_instance.transact({"from": sender}).uncooperativeClose(
+            receiver,
+            open_block_number,
+            balance
+        )
 
 
-def test_uncooperative_close_uint32_overflow(web3, channel_params, get_uraiden_contract, token_instance, get_channel):
+def test_uncooperative_close_uint32_overflow(
+        web3,
+        channel_params,
+        get_uraiden_contract,
+        token_instance,
+        get_channel):
     challenge_period = MAX_UINT32 - 20
     uraiden_instance = get_uraiden_contract(
         [token_instance.address, challenge_period]
@@ -132,27 +222,50 @@ def test_uncooperative_close_uint32_overflow(web3, channel_params, get_uraiden_c
 
     assert web3.eth.getBlock('latest')['number'] + challenge_period == MAX_UINT32 - 1
 
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
 
-def test_uncooperative_close_state(contract_params, channel_params, uraiden_instance, get_channel, get_block):
+def test_uncooperative_close_state(
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        get_channel,
+        get_block):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
-    txn_hash = uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    txn_hash = uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
     channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    assert channel_info[2] == get_block(txn_hash) + contract_params['challenge_period']  # settle_block_number
-    assert channel_info[3] ==  balance  # closing_balance
+    # settle_block_number
+    assert channel_info[2] == get_block(txn_hash) + contract_params['challenge_period']
+    # closing_balance
+    assert channel_info[3] == balance
 
 
-def test_uncooperative_close_event(channel_params, uraiden_instance, get_channel, event_handler):
+def test_uncooperative_close_event(
+        channel_params,
+        uraiden_instance,
+        get_channel,
+        event_handler):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     ev_handler = event_handler(uraiden_instance)
 
-    txn_hash = uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    txn_hash = uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
     ev_handler.add(txn_hash, uraiden_events['closed'], checkClosedEvent(
         sender,
@@ -168,45 +281,138 @@ def test_cooperative_close_call(channel_params, uraiden_instance, get_channel):
     balance = channel_params['balance']
 
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(0x0, open_block_number, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            0x0,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(fake_address, open_block_number, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            fake_address,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, -2, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            -2,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, MAX_UINT32 + 1, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            MAX_UINT32 + 1,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, -2, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            -2,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(TypeError):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, MAX_UINT + 1, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            MAX_UINT + 1,
+            balance_msg_sig,
+            closing_sig
+        )
 
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, bytearray(), closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            bytearray(),
+            closing_sig
+        )
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, bytearray())
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            bytearray()
+        )
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, bytearray(64), closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            bytearray(64),
+            closing_sig
+        )
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, bytearray(64))
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            bytearray(64)
+        )
 
-    uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": sender}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
 
-def test_cooperative_close_fail_no_channel(channel_params, get_accounts, uraiden_instance, get_channel):
+def test_cooperative_close_fail_no_channel(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
     A = get_accounts(1, 5)[0]
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
     # Should fail if the channel does not exist
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(A, open_block_number, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            A,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number - 1, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number - 1,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
 
-    uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": sender}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
 
-def test_cooperative_close_fail_wrong_balance(channel_params, get_accounts, uraiden_instance, token_instance, get_channel):
+def test_cooperative_close_fail_wrong_balance(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        get_channel):
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
     deposit = channel_params['deposit']
@@ -229,20 +435,48 @@ def test_cooperative_close_fail_wrong_balance(channel_params, get_accounts, urai
 
     # Wrong balance as an argument
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance + 1, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance + 1,
+            balance_msg_sig,
+            closing_sig
+        )
 
     # Sender signs wrong balance
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig_fake, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            balance_msg_sig_fake,
+            closing_sig
+        )
 
     # Receiver signs wrong balance
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig_fake)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            closing_sig_fake
+        )
 
-    uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": sender}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
 
-def test_cooperative_close_fail_diff_receiver(channel_params, get_accounts, uraiden_instance, get_channel):
+def test_cooperative_close_fail_diff_receiver(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
     A = get_accounts(1, 5)[0]
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
@@ -258,10 +492,21 @@ def test_cooperative_close_fail_diff_receiver(channel_params, get_accounts, urai
     # Should fail if someone tries to use a closing signature from another receiver
     # with the same sender, block, balance
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": sender}).cooperativeClose(A, open_block_number, balance, balance_msg_sig_A, closing_sig)
+        uraiden_instance.transact({"from": sender}).cooperativeClose(
+            A,
+            open_block_number,
+            balance,
+            balance_msg_sig_A,
+            closing_sig
+        )
 
 
-def test_cooperative_close_call_receiver(channel_params, get_accounts, uraiden_instance, get_channel, print_gas):
+def test_cooperative_close_call_receiver(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel,
+        print_gas):
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
@@ -279,15 +524,25 @@ def test_cooperative_close_call_receiver(channel_params, get_accounts, uraiden_i
         balance,
         closing_sig
     )
-    assert receiver == receiver
+    assert receiver_verified == receiver
 
     # Cooperative close can be called by anyone
-    txn_hash = uraiden_instance.transact({"from": receiver}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    txn_hash = uraiden_instance.transact({"from": receiver}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
     print_gas(txn_hash, 'cooperativeClose')
 
 
-def test_cooperative_close_call_sender(channel_params, get_accounts, uraiden_instance, get_channel):
+def test_cooperative_close_call_sender(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
@@ -305,13 +560,23 @@ def test_cooperative_close_call_sender(channel_params, get_accounts, uraiden_ins
         balance,
         closing_sig
     )
-    assert receiver == receiver
+    assert receiver_verified == receiver
 
     # Cooperative close can be called by anyone
-    uraiden_instance.transact({"from": sender}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": sender}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
 
-def test_cooperative_close_call_delegate(channel_params, get_accounts, uraiden_instance, get_channel):
+def test_cooperative_close_call_delegate(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
     A = get_accounts(1, 5)[0]
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
@@ -330,13 +595,26 @@ def test_cooperative_close_call_delegate(channel_params, get_accounts, uraiden_i
         balance,
         closing_sig
     )
-    assert receiver == receiver
+    assert receiver_verified == receiver
 
     # Cooperative close can be called by anyone
-    uraiden_instance.transact({"from": A}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": A}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
 
-def test_cooperative_close_state(web3, contract_params, channel_params, uraiden_instance, token_instance, get_channel, get_block):
+def test_cooperative_close_state(
+        web3,
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        token_instance,
+        get_channel,
+        get_block):
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
     deposit = channel_params['deposit']
@@ -347,7 +625,13 @@ def test_cooperative_close_state(web3, contract_params, channel_params, uraiden_
     contract_pre_balance = token_instance.call().balanceOf(uraiden_instance.address)
 
     # Cooperative close can be called by anyone
-    uraiden_instance.transact({"from": receiver}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    uraiden_instance.transact({"from": receiver}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
     # Check post closing balances
     receiver_post_balance = receiver_pre_balance + balance
@@ -370,16 +654,32 @@ def test_cooperative_close_state(web3, contract_params, channel_params, uraiden_
 
     # Cannot be called another time
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({"from": receiver}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+        uraiden_instance.transact({"from": receiver}).cooperativeClose(
+            receiver,
+            open_block_number,
+            balance,
+            balance_msg_sig,
+            closing_sig
+        )
 
 
-def test_cooperative_close_event(channel_params, uraiden_instance, get_channel, event_handler):
+def test_cooperative_close_event(
+        channel_params,
+        uraiden_instance,
+        get_channel,
+        event_handler):
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
     ev_handler = event_handler(uraiden_instance)
 
-    txn_hash = uraiden_instance.transact({"from": receiver}).cooperativeClose(receiver, open_block_number, balance, balance_msg_sig, closing_sig)
+    txn_hash = uraiden_instance.transact({"from": receiver}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance,
+        balance_msg_sig,
+        closing_sig
+    )
 
     ev_handler.add(txn_hash, uraiden_events['settled'], checkClosedEvent(
         sender,
@@ -389,12 +689,14 @@ def test_cooperative_close_event(channel_params, uraiden_instance, get_channel, 
     )
     ev_handler.check()
 
-    # TODO:
-    # with pytest.raises(Exception):
-    #    ev_handler.add(txn_hash, uraiden_events['closed'], checkClosedEvent(sender, receiver, open_block_number, balance))
 
-
-def test_settle_call(web3, contract_params, channel_params, uraiden_instance, token_instance, get_channel):
+def test_settle_call(
+        web3,
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        token_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
@@ -402,7 +704,11 @@ def test_settle_call(web3, contract_params, channel_params, uraiden_instance, to
         uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
     # Trigger a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
     web3.testing.mine(contract_params['challenge_period'] + 1)
 
     with pytest.raises(TypeError):
@@ -417,12 +723,21 @@ def test_settle_call(web3, contract_params, channel_params, uraiden_instance, to
     uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
 
-def test_settle_no_channel(web3, contract_params, channel_params, uraiden_instance, get_channel):
+def test_settle_no_channel(
+        web3,
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     # Trigger a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
     web3.testing.mine(contract_params['challenge_period'] + 1)
 
     with pytest.raises(tester.TransactionFailed):
@@ -435,12 +750,21 @@ def test_settle_no_channel(web3, contract_params, channel_params, uraiden_instan
     uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
 
-def test_settle_fail_in_challenge(web3, contract_params, channel_params, uraiden_instance, get_channel):
+def test_settle_fail_in_challenge(
+        web3,
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     # Trigger a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
 
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
@@ -454,13 +778,23 @@ def test_settle_fail_in_challenge(web3, contract_params, channel_params, uraiden
     uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
 
-def test_settle_state(web3, channel_params, contract_params, uraiden_instance, token_instance, get_channel):
+def test_settle_state(
+        web3,
+        channel_params,
+        contract_params,
+        uraiden_instance,
+        token_instance,
+        get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
     deposit = channel_params['deposit']
 
     # Trigger a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
     web3.testing.mine(contract_params['challenge_period'] + 1)
 
     # Keep track of pre closing balances
@@ -494,14 +828,24 @@ def test_settle_state(web3, channel_params, contract_params, uraiden_instance, t
         uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
 
-def test_settle_event(web3, channel_params, contract_params, uraiden_instance, get_channel, event_handler):
+def test_settle_event(
+        web3,
+        channel_params,
+        contract_params,
+        uraiden_instance,
+        get_channel,
+        event_handler):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
     ev_handler = event_handler(uraiden_instance)
 
     # Trigger a challenge period
-    uraiden_instance.transact({"from": sender}).uncooperativeClose(receiver, open_block_number, balance)
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        balance
+    )
     web3.testing.mine(contract_params['challenge_period'] + 1)
 
     txn_hash = uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -513,7 +513,7 @@ def test_cooperative_close_call_receiver(
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
-    sender_verified = uraiden_instance.call().verifyBalanceProof(
+    sender_verified = uraiden_instance.call().extractBalanceProofSignature(
         receiver,
         open_block_number,
         balance,
@@ -521,7 +521,7 @@ def test_cooperative_close_call_receiver(
     )
     assert sender_verified == sender
 
-    receiver_verified = uraiden_instance.call().verifyClosingSignature(
+    receiver_verified = uraiden_instance.call().extractClosingSignature(
         sender,
         open_block_number,
         balance,
@@ -549,7 +549,7 @@ def test_cooperative_close_call_sender(
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
-    sender_verified = uraiden_instance.call().verifyBalanceProof(
+    sender_verified = uraiden_instance.call().extractBalanceProofSignature(
         receiver,
         open_block_number,
         balance,
@@ -557,7 +557,7 @@ def test_cooperative_close_call_sender(
     )
     assert sender_verified == sender
 
-    receiver_verified = uraiden_instance.call().verifyClosingSignature(
+    receiver_verified = uraiden_instance.call().extractClosingSignature(
         sender,
         open_block_number,
         balance,
@@ -584,7 +584,7 @@ def test_cooperative_close_call_delegate(
     (sender, receiver, open_block_number, balance_msg_sig, closing_sig) = get_channel()
     balance = channel_params['balance']
 
-    sender_verified = uraiden_instance.call().verifyBalanceProof(
+    sender_verified = uraiden_instance.call().extractBalanceProofSignature(
         receiver,
         open_block_number,
         balance,
@@ -592,7 +592,7 @@ def test_cooperative_close_call_delegate(
     )
     assert sender_verified == sender
 
-    receiver_verified = uraiden_instance.call().verifyClosingSignature(
+    receiver_verified = uraiden_instance.call().extractClosingSignature(
         sender,
         open_block_number,
         balance,

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -16,7 +16,7 @@ from tests.fixtures import (
     get_block,
     event_handler,
     fake_address,
-    MAX_UINT,
+    MAX_UINT256,
     MAX_UINT32,
     MAX_UINT192,
     uraiden_events
@@ -73,7 +73,7 @@ def test_uncooperative_close_call(channel_params, uraiden_instance, get_channel)
         uraiden_instance.transact({"from": sender}).uncooperativeClose(
             receiver,
             open_block_number,
-            MAX_UINT + 1
+            MAX_UINT256 + 1
         )
 
     uraiden_instance.transact({"from": sender}).uncooperativeClose(
@@ -324,7 +324,7 @@ def test_cooperative_close_call(channel_params, uraiden_instance, get_channel):
         uraiden_instance.transact({"from": sender}).cooperativeClose(
             receiver,
             open_block_number,
-            MAX_UINT + 1,
+            MAX_UINT256 + 1,
             balance_msg_sig,
             closing_sig
         )

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -234,7 +234,8 @@ def test_uncooperative_close_state(
         channel_params,
         uraiden_instance,
         get_channel,
-        get_block):
+        get_block,
+        print_gas):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
 
@@ -249,6 +250,8 @@ def test_uncooperative_close_state(
     assert channel_info[2] == get_block(txn_hash) + contract_params['challenge_period']
     # closing_balance
     assert channel_info[3] == balance
+
+    print_gas(txn_hash, 'uncooperativeClose')
 
 
 def test_uncooperative_close_event(
@@ -784,7 +787,8 @@ def test_settle_state(
         contract_params,
         uraiden_instance,
         token_instance,
-        get_channel):
+        get_channel,
+        print_gas):
     (sender, receiver, open_block_number) = get_channel()[:3]
     balance = channel_params['balance']
     deposit = channel_params['deposit']
@@ -802,7 +806,7 @@ def test_settle_state(
     sender_pre_balance = token_instance.call().balanceOf(sender)
     contract_pre_balance = token_instance.call().balanceOf(uraiden_instance.address)
 
-    uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
+    txn_hash = uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
 
     # Check post closing balances
     receiver_post_balance = receiver_pre_balance + balance
@@ -826,6 +830,8 @@ def test_settle_state(
     # Cannot be called another time
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": sender}).settle(receiver, open_block_number)
+
+    print_gas(txn_hash, 'settle')
 
 
 def test_settle_event(

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -15,7 +15,7 @@ from tests.fixtures import (
     event_handler,
     fake_address,
     empty_address,
-    MAX_UINT,
+    MAX_UINT256,
     MAX_UINT192
 )
 from tests.fixtures_uraiden import (
@@ -48,7 +48,7 @@ def test_channel_223_create(owner, get_accounts, uraiden_instance, token_instanc
     with pytest.raises(TypeError):
         token_instance.transact({"from": sender}).transfer(
             uraiden_instance.address,
-            MAX_UINT + 1,
+            MAX_UINT256 + 1,
             txdata
         )
     with pytest.raises(tester.TransactionFailed):

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -3,6 +3,7 @@ from ethereum import tester
 from tests.fixtures import (
     channel_deposit_bugbounty_limit,
     contract_params,
+    channel_params,
     owner_index,
     owner,
     create_accounts,
@@ -40,7 +41,7 @@ def test_channel_topup_223(
     ev_handler = event_handler(uraiden_instance)
     (sender, receiver, A, B) = get_accounts(4)
     channel_deposit = 700
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)
+    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
     (sender, receiver, open_block_number) = channel
     top_up_deposit = 14
 
@@ -82,7 +83,7 @@ def test_channel_topup_223_bounty_limit(
     token = token_instance
     (sender, receiver, A) = get_accounts(3)
     channel_deposit = 1
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)
+    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
     (sender, receiver, open_block_number) = channel
 
     top_up_data = receiver[2:].zfill(40) + hex(open_block_number)[2:].zfill(8)
@@ -134,7 +135,7 @@ def test_channel_topup_20(
     ev_handler = event_handler(uraiden_instance)
     (sender, receiver, A) = get_accounts(3)
     channel_deposit = 999
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)
+    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
     (sender, receiver, open_block_number) = channel
     top_up_deposit = 14
 
@@ -200,7 +201,7 @@ def test_channel_topup_20_bounty_limit(
     token = token_instance
     (sender, receiver, A) = get_accounts(3)
     channel_deposit = 1
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)
+    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
     (sender, receiver, open_block_number) = channel
 
     # See how many tokens we need to reach channel_deposit_bugbounty_limit

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -15,7 +15,7 @@ from tests.fixtures import (
     get_block,
     event_handler,
     fake_address,
-    MAX_UINT,
+    MAX_UINT256,
     MAX_UINT192,
     uraiden_events
 )

--- a/contracts/tests/test_ecverify.py
+++ b/contracts/tests/test_ecverify.py
@@ -1,7 +1,7 @@
 import pytest
 from ethereum import tester
 from utils import sign
-from tests.utils import balance_proof_hash
+from tests.utils import balance_proof_hash, closing_message_hash
 from tests.fixtures import (
     owner_index,
     owner,
@@ -152,11 +152,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     block = 4804175
     balance = 22000000000000000000
 
-    message_hash = sign.eth_signed_typed_data_message(
-        ('address', ('uint', 32), ('uint', 192), 'address'),
-        ('receiver', 'block_created', 'balance', 'contract'),
-        (receiver, block, balance, uraiden.address)
-    )
+    message_hash = balance_proof_hash(receiver, block, balance, uraiden.address)
     balance_msg_sig, signer = sign.check(message_hash, tester.k2)
     assert signer == A
 
@@ -205,11 +201,7 @@ def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
     block = 4804175
     balance = 22000000000000000000
 
-    message_hash = sign.eth_signed_typed_data_message(
-        ('address', ('uint', 32), ('uint', 192), 'address'),
-        ('sender', 'block_created', 'balance', 'contract'),
-        (sender, block, balance, uraiden.address)
-    )
+    message_hash = closing_message_hash(sender, block, balance, uraiden.address)
     balance_msg_sig, signer = sign.check(message_hash, tester.k2)
     assert signer == A
 

--- a/contracts/tests/test_ecverify.py
+++ b/contracts/tests/test_ecverify.py
@@ -143,7 +143,7 @@ def test_sign(web3, ecverify_test_contract):
     assert verified_address == signer
 
 
-def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
+def test_extract_balance_proof_signature(get_accounts, token_instance, uraiden_instance):
     (A, B) = get_accounts(2)
     token = token_instance
     uraiden = uraiden_instance
@@ -156,7 +156,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     balance_msg_sig, signer = sign.check(message_hash, tester.k2)
     assert signer == A
 
-    signature_address = uraiden.call().verifyBalanceProof(
+    signature_address = uraiden.call().extractBalanceProofSignature(
         receiver,
         block,
         balance,
@@ -165,7 +165,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     assert signature_address == signer
 
     # Wrong receiver
-    signature_address = uraiden.call().verifyBalanceProof(
+    signature_address = uraiden.call().extractBalanceProofSignature(
         B,
         block,
         balance,
@@ -174,7 +174,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     assert signature_address != signer
 
     # Wrong block
-    signature_address = uraiden.call().verifyBalanceProof(
+    signature_address = uraiden.call().extractBalanceProofSignature(
         receiver,
         10,
         balance,
@@ -183,7 +183,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     assert signature_address != signer
 
     # Wrong balance
-    signature_address = uraiden.call().verifyBalanceProof(
+    signature_address = uraiden.call().extractBalanceProofSignature(
         receiver,
         block,
         20,
@@ -192,7 +192,7 @@ def test_verifyBalanceProof(get_accounts, token_instance, uraiden_instance):
     assert signature_address != signer
 
 
-def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
+def test_extract_closing_signature(get_accounts, token_instance, uraiden_instance):
     (A, B) = get_accounts(2)
     token = token_instance
     uraiden = uraiden_instance
@@ -205,7 +205,7 @@ def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
     balance_msg_sig, signer = sign.check(message_hash, tester.k2)
     assert signer == A
 
-    signature_address = uraiden.call().verifyClosingSignature(
+    signature_address = uraiden.call().extractClosingSignature(
         sender,
         block,
         balance,
@@ -214,7 +214,7 @@ def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
     assert signature_address == signer
 
     # Wrong sender
-    signature_address = uraiden.call().verifyClosingSignature(
+    signature_address = uraiden.call().extractClosingSignature(
         B,
         block,
         balance,
@@ -223,7 +223,7 @@ def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
     assert signature_address != signer
 
     # Wrong block
-    signature_address = uraiden.call().verifyClosingSignature(
+    signature_address = uraiden.call().extractClosingSignature(
         sender,
         10,
         balance,
@@ -232,7 +232,7 @@ def test_verifyClosingSignature(get_accounts, token_instance, uraiden_instance):
     assert signature_address != signer
 
     # Wrong balance
-    signature_address = uraiden.call().verifyClosingSignature(
+    signature_address = uraiden.call().extractClosingSignature(
         sender,
         block,
         20,

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -98,7 +98,7 @@ def test_function_access(
 
     # even if TransactionFailed , this means the function is public / external
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact().verifyBalanceProof(receiver, open_block_number, 10, bytearray(65))
+        uraiden_instance.transact().extractBalanceProofSignature(receiver, open_block_number, 10, bytearray(65))
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact().tokenFallback(sender, 10, bytearray(20))
     with pytest.raises(tester.TransactionFailed):

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -18,8 +18,6 @@ from tests.fixtures import (
     print_gas,
     txn_gas,
     get_block,
-    MAX_UINT,
-    MAX_UINT192
 )
 from tests.fixtures_uraiden import (
     token_contract,

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -6,6 +6,7 @@ from tests.fixtures import (
     uraiden_contract_version,
     challenge_period_min,
     contract_params,
+    channel_params,
     owner_index,
     owner,
     create_accounts,
@@ -91,7 +92,7 @@ def test_function_access(
     get_channel):
     (A, B, C, D) = get_accounts(4)
     uraiden_instance2 = uraiden_contract()
-    channel = get_channel(uraiden_instance, token_instance, 100, A, B)
+    channel = get_channel(uraiden_instance, token_instance, 100, A, B)[:3]
     (sender, receiver, open_block_number) = channel
 
     uraiden_instance.call().getKey(*channel)
@@ -107,7 +108,7 @@ def test_function_access(
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact().topUpERC20(receiver, open_block_number, 10)
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact().uncooperativeClose(receiver, open_block_number, 10, bytearray(65))
+        uraiden_instance.transact().uncooperativeClose(receiver, open_block_number, 10)
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact().cooperativeClose(receiver, open_block_number, 10, bytearray(65), bytearray(65))
     with pytest.raises(tester.TransactionFailed):
@@ -144,7 +145,7 @@ def test_version(
 
 def test_get_channel_info(web3, get_accounts, uraiden_instance, token_instance, get_channel):
     (A, B, C, D) = get_accounts(4)
-    channel = get_channel(uraiden_instance, token_instance, 100, C, D)
+    channel = get_channel(uraiden_instance, token_instance, 100, C, D)[:3]
     (sender, receiver, open_block_number) = channel
 
     with pytest.raises(tester.TransactionFailed):

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -3,17 +3,17 @@ from utils.sign import eth_signed_typed_data_message
 
 def balance_proof_hash(receiver, block, balance, contract):
     return eth_signed_typed_data_message(
-        ('address', ('uint', 32), ('uint', 192), 'address'),
-        ('receiver', 'block_created', 'balance', 'contract'),
-        (receiver, block, balance, contract)
+        ('string', 'address', ('uint', 32), ('uint', 192), 'address'),
+        ('messageID', 'receiver', 'block_created', 'balance', 'contract'),
+        ('Sender balance proof signature', receiver, block, balance, contract)
     )
 
 
 def closing_message_hash(sender, block, balance, contract):
     return eth_signed_typed_data_message(
-        ('address', ('uint', 32), ('uint', 192), 'address'),
-        ('sender', 'block_created', 'balance', 'contract'),
-        (sender, block, balance, contract)
+        ('string', 'address', ('uint', 32), ('uint', 192), 'address'),
+        ('messageID', 'sender', 'block_created', 'balance', 'contract'),
+        ('Receiver closing signature', sender, block, balance, contract)
     )
 
 

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -9,6 +9,14 @@ def balance_proof_hash(receiver, block, balance, contract):
     )
 
 
+def closing_message_hash(sender, block, balance, contract):
+    return eth_signed_typed_data_message(
+        ('address', ('uint', 32), ('uint', 192), 'address'),
+        ('sender', 'block_created', 'balance', 'contract'),
+        (sender, block, balance, contract)
+    )
+
+
 def print_logs(contract, event, name=''):
     transfer_filter_past = contract.pastEvents(event)
     past_events = transfer_filter_past.get()

--- a/contracts/tests/utils.py
+++ b/contracts/tests/utils.py
@@ -4,7 +4,7 @@ from utils.sign import eth_signed_typed_data_message
 def balance_proof_hash(receiver, block, balance, contract):
     return eth_signed_typed_data_message(
         ('string', 'address', ('uint', 32), ('uint', 192), 'address'),
-        ('messageID', 'receiver', 'block_created', 'balance', 'contract'),
+        ('message_id', 'receiver', 'block_created', 'balance', 'contract'),
         ('Sender balance proof signature', receiver, block, balance, contract)
     )
 
@@ -12,7 +12,7 @@ def balance_proof_hash(receiver, block, balance, contract):
 def closing_message_hash(sender, block, balance, contract):
     return eth_signed_typed_data_message(
         ('string', 'address', ('uint', 32), ('uint', 192), 'address'),
-        ('messageID', 'sender', 'block_created', 'balance', 'contract'),
+        ('message_id', 'sender', 'block_created', 'balance', 'contract'),
         ('Receiver closing signature', sender, block, balance, contract)
     )
 


### PR DESCRIPTION
fixes https://github.com/raiden-network/microraiden/issues/266

Open to suggestions for the `message_id` values.
As suggested in https://github.com/raiden-network/microraiden/issues/134#issuecomment-347144899

tl;dr

```python
# extractBalanceProofSignature
       bytes32 message_hash = keccak256(
            keccak256(
                'string message_id',
                'address receiver',
                'uint32 block_created',
                'uint192 balance',
                'address contract'
            ),
            keccak256(
                'Sender balance proof signature',
                _receiver_address,
                _open_block_number,
                _balance,
                address(this)
            )
        );

# extractClosingSignature
    bytes32 message_hash = keccak256(
            keccak256(
                'string message_id',
                'address sender',
                'uint32 block_created',
                'uint192 balance',
                'address contract'
            ),
            keccak256(
                'Receiver closing signature',
                _sender_address,
                _open_block_number,
                _balance,
                address(this)
            )
        );

# callable by sender, receiver, delegate; closes channel immediately
function cooperativeClose(
        address _receiver_address,
        uint32 _open_block_number,
        uint192 _balance,
        bytes _balance_msg_sig,
        bytes _closing_sig)
        external
    {...}

# called just by the sender, starts the challenge period
function uncooperativeClose(
        address _receiver_address,
        uint32 _open_block_number,
        uint192 _balance)
        external
    {...}
```

- rename `verifyBalanceProof` to `extractBalanceProofSignature`, add `extractClosingSignature`
- closing signature = receiver signs channel data (sender address, block, balance, uRaiden contract address) instead of the sender's signature.
- refactor channel closing, support delegates (now, the eip712 for the closing signature really makes sense, because the receiver might use an external service to run uRaiden).
-  `cooperativeClose` (needs signatures from both sender and receiver) - can be called by sender, receiver or a delegate; the closing signature is only given when at least 1 of the parties (the receiver) wants to close the channel - so delegate closing should be safe.
   - for code simplicity, we require both of the signatures regardless of `msg.sender`
- `uncooperativeClose` - called only by the sender; no need for the sender's signature here anymore. this cannot be done by a delegate (no reason for delegates anyway)


Current gas cost (populus):
- cooperativeClose: 70429
- uncooperativeClose: 53753
- settle: 40538
