### PR TITLE
Update requirements.txt

### DIFF
--- a/microraiden/requirements.txt
+++ b/microraiden/requirements.txt
@@ -1,3 +1,5 @@
+ethereum-utils<0.5.0
+ethereum-abi-utils==0.4.0
 coincurve
 rlp>=0.4.3,<0.6.0
 flask


### PR DESCRIPTION
ethereum-utils library refuses to start in version >0.6.0 and
ethereum-abi-utils also raises an exception in version >0.4.0

The reason for this is rename of the library to eth-utils and
eth-abi-utils, respectively.

Because these two are dependencies of other libraries, we must
freeze versions until it's fixed upstream.