### PR TITLE
Add overflow check for challenge period

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -392,6 +392,7 @@ contract RaidenMicroTransferChannels {
 
         // Mark channel as closed
         closing_requests[key].settle_block_number = uint32(block.number) + challenge_period;
+        require(closing_requests[key].settle_block_number > block.number);
         closing_requests[key].closing_balance = _balance;
         ChannelCloseRequested(msg.sender, _receiver_address, _open_block_number, _balance);
     }


### PR DESCRIPTION
As reported in the bug bounty there is a potential (but quite unlikely
as this contract is not going to be here for that long and challenge
period is set to 500) for overflow if there is a very high challenge
period and if the block number is very high.

We add an assertion for such a scenario