### PR TITLE
Faster ETH ticker test

### DIFF
--- a/microraiden/microraiden/examples/eth_ticker.py
+++ b/microraiden/microraiden/examples/eth_ticker.py
@@ -53,8 +53,11 @@ class ETHTickerClient(ttk.Frame):
     def __init__(
             self,
             sender_privkey: str,
-            httpclient: DefaultHTTPClient = None
+            httpclient: DefaultHTTPClient = None,
+            poll_interval: float = 5
     ) -> None:
+        self.poll_interval = poll_interval
+
         self.root = tkinter.Tk()
         ttk.Frame.__init__(self, self.root)
         self.root.title('µRaiden ETH Ticker')
@@ -79,7 +82,7 @@ class ETHTickerClient(ttk.Frame):
 
     def run(self):
         self.running = True
-        self.root.after(1000, self.query_price)
+        self.root.after(0, self.query_price)
         self.root.mainloop()
 
     def query_price(self):
@@ -96,7 +99,7 @@ class ETHTickerClient(ttk.Frame):
             log.warning('No response.')
 
         if self.running:
-            self.root.after(5000, self.query_price)
+            self.root.after(int(self.poll_interval * 1000), self.query_price)
         self.active_query = False
 
     def close(self):

--- a/microraiden/microraiden/test/test_eth_ticker.py
+++ b/microraiden/microraiden/test/test_eth_ticker.py
@@ -1,8 +1,11 @@
 import pytest  # noqa: F401
+from _pytest.monkeypatch import MonkeyPatch
+from flask import jsonify
 
 from microraiden import DefaultHTTPClient
 from microraiden.examples.eth_ticker import ETHTickerClient, ETHTickerProxy
 from microraiden.proxy.paywalled_proxy import PaywalledProxy
+from microraiden.proxy.resources import PaywalledProxyUrl
 
 
 @pytest.mark.needs_xorg
@@ -11,20 +14,30 @@ def test_eth_ticker(
         default_http_client: DefaultHTTPClient,
         sender_privkey: str,
         receiver_privkey: str,
+        monkeypatch: MonkeyPatch
 ):
-    proxy = ETHTickerProxy(receiver_privkey, proxy=empty_proxy) # noqa
-    ticker = ETHTickerClient(sender_privkey, httpclient=default_http_client)
+    def get_patched(*args, **kwargs):
+        body = {
+            'mid': '682.435', 'bid': '682.18', 'ask': '682.69', 'last_price': '683.16',
+            'low': '532.97', 'high': '684.0', 'volume': '724266.25906224',
+            'timestamp': '1513167820.721733'
+        }
+        return jsonify(body)
+
+    monkeypatch.setattr(PaywalledProxyUrl, 'get', get_patched)
+
+    ETHTickerProxy(receiver_privkey, proxy=empty_proxy)
+    ticker = ETHTickerClient(sender_privkey, httpclient=default_http_client, poll_interval=0.5)
 
     def post():
         ticker.close()
 
-        # This test fails if ETH price is below 100 USD. But why even bother anymore if it does?
-        assert float(ticker.pricevar.get().split()[0]) > 100
+        assert ticker.pricevar.get() == '683.16 USD'
         client = default_http_client.client
         assert len(client.get_open_channels()) == 0
         ticker.success = True
 
     ticker.success = False
-    ticker.root.after(5000, post)
+    ticker.root.after(1500, post)
     ticker.run()
     assert ticker.success


### PR DESCRIPTION
The ETH ticker test now mocks the bitfinex API call and allows for faster polling times.

The test might in some cases be too short for the ticker window to appear. It should at most take 2 seconds.