### PR TITLE
Bug fix: proxy resource headers take precedence over default headers

### DIFF
--- a/microraiden/microraiden/test/test_proxy.py
+++ b/microraiden/microraiden/test/test_proxy.py
@@ -7,7 +7,7 @@ from munch import Munch
 from microraiden import HTTPHeaders, Client
 from microraiden.proxy.resources import Expensive
 from microraiden.proxy.paywalled_proxy import PaywalledProxy
-from flask import request
+from flask import request, jsonify
 
 import logging
 log = logging.getLogger(__name__)
@@ -46,6 +46,16 @@ class DynamicMethodResource(StaticPriceResource):
             'DELETE': 4
         }
         return prices[request.method]
+
+
+class TextResource(Expensive):
+    def get(self, url):
+        return 'GET', 200, {'Content-Type': 'text'}
+
+
+class JSONResource(Expensive):
+    def get(self, url):
+        return jsonify({'GET': 1})
 
 
 def assert_method(method, url, headers, channel, expected_reply, expected_price=3):
@@ -223,3 +233,72 @@ def test_method_price(
                   endpoint_url + '/resource',
                   headers, channel, 'DEL',
                   expected_price=4)
+
+
+def test_text(
+        empty_proxy: PaywalledProxy,
+        api_endpoint_address: str,
+        client: Client,
+        wait_for_blocks
+):
+    proxy = empty_proxy
+    endpoint_url = "http://" + api_endpoint_address
+
+    proxy.add_paywalled_resource(TextResource, '/resource', 3)
+
+    # test GET
+    response = requests.get(endpoint_url + '/resource')
+    assert response.status_code == 402
+    headers = HTTPHeaders.deserialize(response.headers)
+    assert int(headers.price) == 3
+
+    channel = client.get_suitable_channel(headers.receiver_address, int(headers.price) * 4)
+    wait_for_blocks(6)
+    channel.update_balance(int(headers.price))
+
+    headers = Munch()
+    headers.balance = str(channel.balance)
+    headers.balance_signature = encode_hex(channel.balance_sig)
+    headers.sender_address = channel.sender
+    headers.open_block = str(channel.block)
+    headers = HTTPHeaders.serialize(headers)
+
+    response = requests.get(endpoint_url + '/resource', headers=headers)
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text'
+    assert response.text == 'GET'
+
+
+def test_explicit_json(
+        empty_proxy: PaywalledProxy,
+        api_endpoint_address: str,
+        client: Client,
+        wait_for_blocks
+):
+    proxy = empty_proxy
+    endpoint_url = "http://" + api_endpoint_address
+
+    proxy.add_paywalled_resource(JSONResource, '/resource', 3)
+
+    # test GET
+    response = requests.get(endpoint_url + '/resource')
+    assert response.status_code == 402
+    headers = HTTPHeaders.deserialize(response.headers)
+    assert int(headers.price) == 3
+
+    channel = client.get_suitable_channel(headers.receiver_address, int(headers.price) * 4)
+    wait_for_blocks(6)
+    channel.update_balance(int(headers.price))
+
+    headers = Munch()
+    headers.balance = str(channel.balance)
+    headers.balance_signature = encode_hex(channel.balance_sig)
+    headers.sender_address = channel.sender
+    headers.open_block = str(channel.block)
+    headers = HTTPHeaders.serialize(headers)
+
+    response = requests.get(endpoint_url + '/resource', headers=headers)
+    assert response.status_code == 200
+    # If headers don't merge properly, this results in 'application/json,application/json'.
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response.json() == {'GET': 1}


### PR DESCRIPTION
This came up in a µRaiden application: When the returned resource had an explicit content type (for example `application/json` from a `jsonify()` call) the respective header wasn't merged properly but simply extended. This resulted in headers like `'Content-Type': 'application/json,application/json'` or `'Content-Type': 'application/json,text'`.

In this PR, header fields returned by the resource take precedence over default headers. That includes possibly overriding `RDN-...` fields. Not sure one would want that but just note that it's possible now.