### PR TITLE
Contract tests refactor open

### DIFF
--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -11,6 +11,8 @@ MAX_UINT32 = 2 ** 32 - 1
 fake_address = '0x03432'
 empty_address = '0x0000000000000000000000000000000000000000'
 passphrase = '0'
+
+# recheck test_create_token_fallback_uint_conversion when bug bounty limit is removed
 uraiden_contract_version = '0.1.0'
 channel_deposit_bugbounty_limit = 100 * 10 ** 18
 challenge_period_min = 500

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -21,11 +21,6 @@ contract_args = [
         'challenge_period': 500
     },
     {
-        'decimals': 18,
-        'supply': 2 ** 200,  # test tokenFallback uint256 -> uint192 conversion
-        'challenge_period': 501
-    },
-    {
         'decimals': 0,
         'supply': 10 ** 26,
         'challenge_period': 502

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -123,30 +123,39 @@ def test_channel_erc223_create_bounty_limit(
 
 
 def test_create_token_fallback_uint_conversion(
-    contract_params,
-    owner,
-    get_accounts,
-    uraiden_instance,
-    token_instance):
-    token = token_instance
+        owner,
+        get_accounts,
+        uraiden_contract,
+        get_token_contract):
+    token = get_token_contract([MAX_UINT192 + 100, 'CustomToken', 'TKN', 18])
+    uraiden = uraiden_contract(token)
     (sender, receiver) = get_accounts(2)
-
-    # Make sure you have a fixture with a supply > 2 ** 192 + 100
-    deposit = contract_params['supply'] - 100
     txdata = bytes.fromhex(receiver[2:].zfill(40))
 
     # Fund accounts with tokens
-    token.transact({"from": owner}).transfer(sender, deposit)
-    assert token.call().balanceOf(sender) == deposit
+    token.transact({"from": owner}).transfer(sender, MAX_UINT192 + 5)
+    assert token.call().balanceOf(sender) == MAX_UINT192 + 5
 
     # Open a channel with tokenFallback
-    if deposit > 2 ** 192:
-        with pytest.raises(tester.TransactionFailed):
-            txn_hash = token_instance.transact({"from": sender}).transfer(
-                uraiden_instance.address,
-                deposit,
-                txdata
-            )
+    # uint192 deposit = uint192(_deposit), where _deposit is uint256
+    with pytest.raises(tester.TransactionFailed):
+        txn_hash = token_instance.transact({"from": sender}).transfer(
+            uraiden_instance.address,
+            MAX_UINT192 + 1,
+            txdata
+        )
+    with pytest.raises(tester.TransactionFailed):
+        txn_hash = token_instance.transact({"from": sender}).transfer(
+            uraiden_instance.address,
+            MAX_UINT192 + 4,
+            txdata
+        )
+
+    txn_hash = token_instance.transact({"from": sender}).transfer(
+        uraiden_instance.address,
+        MAX_UINT192,
+        txdata
+    )
 
 
 def test_channel_erc223_event(

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -139,23 +139,24 @@ def test_create_token_fallback_uint_conversion(
     # Open a channel with tokenFallback
     # uint192 deposit = uint192(_deposit), where _deposit is uint256
     with pytest.raises(tester.TransactionFailed):
-        txn_hash = token.transact({"from": sender}).transfer(
+        token.transact({"from": sender}).transfer(
             uraiden.address,
             MAX_UINT192 + 1,
             txdata
         )
     with pytest.raises(tester.TransactionFailed):
-        txn_hash = token.transact({"from": sender}).transfer(
+        token.transact({"from": sender}).transfer(
             uraiden.address,
             MAX_UINT192 + 4,
             txdata
         )
 
-    txn_hash = token.transact({"from": sender}).transfer(
-        uraiden.address,
-        MAX_UINT192,
-        txdata
-    )
+    # TODO - uncomment this after channel_deposit_bugbounty_limit is removed
+    # txn_hash = token.transact({"from": sender}).transfer(
+    #     uraiden.address,
+    #     MAX_UINT192,
+    #     txdata
+    # )
 
 
 def test_channel_erc223_event(

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -3,6 +3,7 @@ from ethereum import tester
 from tests.fixtures import (
     channel_deposit_bugbounty_limit,
     contract_params,
+    channel_params,
     owner_index,
     owner,
     create_accounts,
@@ -16,7 +17,8 @@ from tests.fixtures import (
     fake_address,
     empty_address,
     MAX_UINT256,
-    MAX_UINT192
+    MAX_UINT192,
+    uraiden_events
 )
 from tests.fixtures_uraiden import (
     token_contract,
@@ -24,6 +26,7 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    checkCreatedEvent
 )
 
 
@@ -32,7 +35,6 @@ def test_channel_223_create(owner, get_accounts, uraiden_instance, token_instanc
     (sender, receiver, C, D) = get_accounts(4)
     deposit = 1000
     txdata = bytes.fromhex(receiver[2:].zfill(40))
-    # txdata_D = bytes.fromhex(D[2:].zfill(40))
     txdata_fake = txdata[1:]
 
     # Fund accounts with tokens
@@ -115,6 +117,56 @@ def test_channel_223_create_bounty_limit(get_block, owner, get_accounts, uraiden
     assert channel_data[1] == channel_deposit_bugbounty_limit
 
 
+def test_create_token_fallback_uint_conversion(
+    contract_params,
+    owner,
+    get_accounts,
+    uraiden_instance,
+    token_instance):
+    token = token_instance
+    (sender, receiver) = get_accounts(2)
+
+    # Make sure you have a fixture with a supply > 2 ** 192 + 100
+    deposit = contract_params['supply'] - 100
+    txdata = bytes.fromhex(receiver[2:].zfill(40))
+
+    # Fund accounts with tokens
+    token.transact({"from": owner}).transfer(sender, deposit)
+    assert token.call().balanceOf(sender) == deposit
+
+    # Open a channel with tokenFallback
+    if deposit > 2 ** 192:
+        with pytest.raises(tester.TransactionFailed):
+            txn_hash = token_instance.transact({"from": sender}).transfer(
+                uraiden_instance.address,
+                deposit,
+                txdata
+            )
+
+
+def test_channel_223_event(owner, get_accounts, uraiden_instance, token_instance, event_handler, print_gas):
+    token = token_instance
+    ev_handler = event_handler(uraiden_instance)
+    (sender, receiver) = get_accounts(2)
+    deposit = 1000
+    txdata = bytes.fromhex(receiver[2:].zfill(40))
+
+    # Fund accounts with tokens
+    token.transact({"from": owner}).transfer(sender, deposit + 100)
+
+    txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, 1000, txdata)
+
+    # Check creation event
+    ev_handler.add(
+        txn_hash,
+        uraiden_events['created'],
+        checkCreatedEvent(sender, receiver, deposit)
+    )
+    ev_handler.check()
+
+    print_gas(txn_hash, 'channel_223_create')
+
+
 def test_channel_20_create(owner, get_accounts, uraiden_instance, token_instance):
     token = token_instance
     (sender, receiver) = get_accounts(2)
@@ -190,28 +242,80 @@ def test_channel_20_create_bounty_limit(owner, get_accounts, uraiden_instance, t
     assert channel_data[1] == channel_deposit_bugbounty_limit
 
 
-def test_create_token_fallback_uint_conversion(
-    contract_params,
-    owner,
-    get_accounts,
-    uraiden_instance,
-    token_instance):
+def test_channel_20_event(owner, get_accounts, uraiden_instance, token_instance, event_handler, txn_gas, print_gas):
     token = token_instance
+    ev_handler = event_handler(uraiden_instance)
     (sender, receiver) = get_accounts(2)
-
-    # Make sure you have a fixture with a supply > 2 ** 192 + 100
-    deposit = contract_params['supply'] - 100
-    txdata = bytes.fromhex(receiver[2:].zfill(40))
+    deposit = 1000
+    gas_used = 0
 
     # Fund accounts with tokens
-    token.transact({"from": owner}).transfer(sender, deposit)
-    assert token.call().balanceOf(sender) == deposit
+    token.transact({"from": owner}).transfer(sender, deposit + 100)
 
-    # Open a channel with tokenFallback
-    if deposit > 2 ** 192:
-        with pytest.raises(tester.TransactionFailed):
-            txn_hash = token_instance.transact({"from": sender}).transfer(
-                uraiden_instance.address,
-                deposit,
-                txdata
-            )
+    # Approve token allowance
+    txn_hash_approve = token_instance.transact({"from": sender}).approve(uraiden_instance.address, deposit)
+    gas_used += txn_gas(txn_hash_approve)
+
+    # Create channel
+    txn_hash = uraiden_instance.transact({"from": sender}).createChannelERC20(receiver, deposit)
+
+    # Check creation event
+    ev_handler.add(
+        txn_hash,
+        uraiden_events['created'],
+        checkCreatedEvent(sender, receiver, deposit)
+    )
+    ev_handler.check()
+
+    print_gas(txn_hash, 'channel_20_create', gas_used)
+
+
+def test_channel_create_state(owner, channel_params, get_accounts, uraiden_instance, token_instance, get_block):
+    token = token_instance
+    uraiden = uraiden_instance
+    (sender, receiver) = get_accounts(2)
+    deposit = channel_params['deposit']
+    contract_type = channel_params['type']
+
+    # Fund accounts with tokens
+    token.transact({"from": owner}).transfer(sender, deposit + 100)
+    token.transact({"from": owner}).transfer(receiver, 20)
+
+    # Memorize balances for tests
+    uraiden_pre_balance = token.call().balanceOf(uraiden.address)
+    sender_pre_balance = token.call().balanceOf(sender)
+    receiver_pre_balance = token.call().balanceOf(receiver)
+
+    if contract_type == '20':
+        token.transact({"from": sender}).approve(
+            uraiden.address,
+            deposit
+        )
+        txn_hash = uraiden.transact({"from": sender}).createChannelERC20(
+            receiver,
+            deposit
+        )
+    else:
+        txdata = bytes.fromhex(receiver[2:].zfill(40))
+        txn_hash = token.transact({"from": sender}).transfer(
+            uraiden.address,
+            deposit,
+            txdata
+        )
+
+    # Check token balances post channel creation
+    uraiden_balance = uraiden_pre_balance + deposit
+    assert token.call().balanceOf(uraiden.address) == uraiden_balance
+    assert token.call().balanceOf(sender) == sender_pre_balance - deposit
+    assert token.call().balanceOf(receiver) == receiver_pre_balance
+
+    open_block_number = get_block(txn_hash)
+    channel_data = uraiden.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[0] == uraiden.call().getKey(
+        sender,
+        receiver,
+        open_block_number
+    )
+    assert channel_data[1] == deposit
+    assert channel_data[2] == 0
+    assert channel_data[3] == 0

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -139,20 +139,20 @@ def test_create_token_fallback_uint_conversion(
     # Open a channel with tokenFallback
     # uint192 deposit = uint192(_deposit), where _deposit is uint256
     with pytest.raises(tester.TransactionFailed):
-        txn_hash = token_instance.transact({"from": sender}).transfer(
-            uraiden_instance.address,
+        txn_hash = token.transact({"from": sender}).transfer(
+            uraiden.address,
             MAX_UINT192 + 1,
             txdata
         )
     with pytest.raises(tester.TransactionFailed):
-        txn_hash = token_instance.transact({"from": sender}).transfer(
-            uraiden_instance.address,
+        txn_hash = token.transact({"from": sender}).transfer(
+            uraiden.address,
             MAX_UINT192 + 4,
             txdata
         )
 
-    txn_hash = token_instance.transact({"from": sender}).transfer(
-        uraiden_instance.address,
+    txn_hash = token.transact({"from": sender}).transfer(
+        uraiden.address,
         MAX_UINT192,
         txdata
     )

--- a/contracts/tests/test_channel_create.py
+++ b/contracts/tests/test_channel_create.py
@@ -30,7 +30,7 @@ from tests.fixtures_uraiden import (
 )
 
 
-def test_channel_223_create(owner, get_accounts, uraiden_instance, token_instance):
+def test_channel_erc223_create(owner, get_accounts, uraiden_instance, token_instance):
     token = token_instance
     (sender, receiver, C, D) = get_accounts(4)
     deposit = 1000
@@ -80,7 +80,12 @@ def test_channel_223_create(owner, get_accounts, uraiden_instance, token_instanc
     token_instance.transact({"from": sender}).transfer(uraiden_instance.address, deposit, txdata)
 
 
-def test_channel_223_create_bounty_limit(get_block, owner, get_accounts, uraiden_instance, token_instance):
+def test_channel_erc223_create_bounty_limit(
+        get_block,
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance):
     token = token_instance
     (sender, receiver, C, D) = get_accounts(4)
     txdata = bytes.fromhex(receiver[2:].zfill(40))
@@ -144,7 +149,13 @@ def test_create_token_fallback_uint_conversion(
             )
 
 
-def test_channel_223_event(owner, get_accounts, uraiden_instance, token_instance, event_handler, print_gas):
+def test_channel_erc223_event(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        event_handler,
+        print_gas):
     token = token_instance
     ev_handler = event_handler(uraiden_instance)
     (sender, receiver) = get_accounts(2)
@@ -154,7 +165,11 @@ def test_channel_223_event(owner, get_accounts, uraiden_instance, token_instance
     # Fund accounts with tokens
     token.transact({"from": owner}).transfer(sender, deposit + 100)
 
-    txn_hash = token_instance.transact({"from": sender}).transfer(uraiden_instance.address, 1000, txdata)
+    txn_hash = token_instance.transact({"from": sender}).transfer(
+        uraiden_instance.address,
+        1000,
+        txdata
+    )
 
     # Check creation event
     ev_handler.add(
@@ -167,7 +182,7 @@ def test_channel_223_event(owner, get_accounts, uraiden_instance, token_instance
     print_gas(txn_hash, 'channel_223_create')
 
 
-def test_channel_20_create(owner, get_accounts, uraiden_instance, token_instance):
+def test_channel_erc20_create(owner, get_accounts, uraiden_instance, token_instance):
     token = token_instance
     (sender, receiver) = get_accounts(2)
     deposit = 1000
@@ -203,7 +218,12 @@ def test_channel_20_create(owner, get_accounts, uraiden_instance, token_instance
     uraiden_instance.transact({"from": sender}).createChannelERC20(receiver, deposit)
 
 
-def test_channel_20_create_bounty_limit(owner, get_accounts, uraiden_instance, token_instance, get_block):
+def test_channel_erc20_create_bounty_limit(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        get_block):
     token = token_instance
     (sender, receiver) = get_accounts(2)
 
@@ -242,7 +262,14 @@ def test_channel_20_create_bounty_limit(owner, get_accounts, uraiden_instance, t
     assert channel_data[1] == channel_deposit_bugbounty_limit
 
 
-def test_channel_20_event(owner, get_accounts, uraiden_instance, token_instance, event_handler, txn_gas, print_gas):
+def test_channel_erc20_event(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        event_handler,
+        txn_gas,
+        print_gas):
     token = token_instance
     ev_handler = event_handler(uraiden_instance)
     (sender, receiver) = get_accounts(2)
@@ -270,7 +297,13 @@ def test_channel_20_event(owner, get_accounts, uraiden_instance, token_instance,
     print_gas(txn_hash, 'channel_20_create', gas_used)
 
 
-def test_channel_create_state(owner, channel_params, get_accounts, uraiden_instance, token_instance, get_block):
+def test_channel_create_state(
+        owner,
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        get_block):
     token = token_instance
     uraiden = uraiden_instance
     (sender, receiver) = get_accounts(2)

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -25,8 +25,7 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
-    get_channel,
-    event_handler
+    get_channel
 )
 # from tests.test_channel_create import get_channel
 


### PR DESCRIPTION
To be reviewed after https://github.com/raiden-network/microraiden/pull/273 is merged.

- move create channel tests from the `get_channel` fixture used in all tests to dedicated tests
- shortens travis time relative to the above PR