### PR TITLE
Requests kwarg popping moved to utility module

### DIFF
--- a/microraiden/microraiden/requests/__init__.py
+++ b/microraiden/microraiden/requests/__init__.py
@@ -1,24 +1,12 @@
-import inspect
-
 from requests import Response
 
 from microraiden import Session, Client
+from microraiden.utils import pop_function_kwargs
 
 
 def request(method: str, url: str, **kwargs) -> Response:
-    session_kwargs = {
-        kw: arg for kw, arg in kwargs.items()
-        if kw in inspect.signature(Session.__init__).parameters
-    }
-    client_kwargs = {
-        kw: arg for kw, arg in kwargs.items()
-        if kw in inspect.signature(Client.__init__).parameters
-    }
-
-    for kw in session_kwargs:
-        kwargs.pop(kw)
-    for kw in client_kwargs:
-        kwargs.pop(kw)
+    session_kwargs = pop_function_kwargs(kwargs, Session.__init__)
+    client_kwargs = pop_function_kwargs(kwargs, Client.__init__)
 
     session_kwargs.update(client_kwargs)
 

--- a/microraiden/microraiden/test/test_utils.py
+++ b/microraiden/microraiden/test/test_utils.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from microraiden.utils.misc import get_function_kwargs, pop_function_kwargs
+
+
+def test_get_function_kwargs():
+    def function(a: str, b: int, something: Any):
+        pass
+
+    kwargs = dict(b=5, c='string', something=3.14)
+    function_kwargs = get_function_kwargs(kwargs, function)
+    assert function_kwargs == dict(b=5, something=3.14)
+
+
+def test_pop_function_kwargs():
+    def function(a: str, b: int, something: Any):
+        pass
+
+    kwargs = dict(b=5, c='string', something=3.14)
+    function_kwargs = pop_function_kwargs(kwargs, function)
+    assert function_kwargs == dict(b=5, something=3.14)
+    assert kwargs == dict(c='string')

--- a/microraiden/microraiden/utils/__init__.py
+++ b/microraiden/microraiden/utils/__init__.py
@@ -38,6 +38,11 @@ from .private_key import (
     get_private_key
 )
 
+from .misc import (
+    get_function_kwargs,
+    pop_function_kwargs
+)
+
 __all__ = [
     generate_privkey,
     pubkey_to_addr,
@@ -71,5 +76,8 @@ __all__ = [
     wait_for_transaction,
 
     check_permission_safety,
-    get_private_key
+    get_private_key,
+
+    get_function_kwargs,
+    pop_function_kwargs
 ]

--- a/microraiden/microraiden/utils/misc.py
+++ b/microraiden/microraiden/utils/misc.py
@@ -1,0 +1,17 @@
+import inspect
+from typing import Any, Dict, Callable
+
+
+def get_function_kwargs(kwargs: Dict[str, Any], function: Callable):
+    return {
+        kw: arg for kw, arg in kwargs.items()
+        if kw in inspect.signature(function).parameters
+    }
+
+
+def pop_function_kwargs(kwargs: Dict[str, Any], function: Callable):
+    function_kwargs = get_function_kwargs(kwargs, function)
+    for kw in function_kwargs:
+        kwargs.pop(kw)
+
+    return function_kwargs


### PR DESCRIPTION
I noticed I might have to reuse the `kwarg` popping magic in the `microraiden.requests` module somewhere else, and @pcppcp mentioned he might need it in some places too, so here's a tiny PR pulling that functionality out into a module, covered by tests.