### PR TITLE
Infura support, logging tweaks

### DIFF
--- a/microraiden/microraiden/client/channel.py
+++ b/microraiden/microraiden/client/channel.py
@@ -126,7 +126,7 @@ class Channel:
             self.deposit += deposit
             return event
         else:
-            log.error('No event received.')
+            log.error('No ChannelToppedUp event received.')
             return None
 
     def close(self, balance=None):
@@ -176,7 +176,7 @@ class Channel:
             self.state = Channel.State.settling
             return event
         else:
-            log.error('No event received.')
+            log.error('No ChannelCloseRequested event received.')
             return None
 
     def close_cooperatively(self, closing_sig: bytes):
@@ -234,7 +234,7 @@ class Channel:
             self.state = Channel.State.closed
             return event
         else:
-            log.error('No event received.')
+            log.error('No ChannelSettled event received.')
             return None
 
     def settle(self):
@@ -291,7 +291,7 @@ class Channel:
             self.on_settle(self)
             return event
         else:
-            log.error('No event received.')
+            log.error('No ChannelSettled event received.')
             return None
 
     def create_transfer(self, value):

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -4,7 +4,6 @@ from typing import List
 import os
 from eth_utils import decode_hex, is_same_address, is_hex, remove_0x_prefix, to_checksum_address
 from web3 import Web3, HTTPProvider
-from microraiden import config
 from microraiden.utils import (
     privkey_to_addr,
     get_private_key,

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -3,7 +3,9 @@ from typing import List
 
 import os
 from eth_utils import decode_hex, is_same_address, is_hex, remove_0x_prefix, to_checksum_address
-from web3 import Web3, HTTPProvider
+from web3 import Web3
+from web3.providers.rpc import HTTPProvider
+
 from microraiden.utils import (
     privkey_to_addr,
     get_private_key,

--- a/microraiden/microraiden/make_helpers.py
+++ b/microraiden/microraiden/make_helpers.py
@@ -13,6 +13,7 @@ from microraiden.exceptions import (
 from microraiden import constants
 from microraiden.config import NETWORK_CFG
 from microraiden.proxy.paywalled_proxy import PaywalledProxy
+from microraiden.utils import privkey_to_addr
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +70,7 @@ def make_paywalled_proxy(
 ) -> PaywalledProxy:
     if web3 is None:
         web3 = Web3(HTTPProvider(constants.WEB3_PROVIDER_DEFAULT, request_kwargs={'timeout': 60}))
+        web3.eth.defaultAccount = privkey_to_addr(private_key)
         contract_address = contract_address or NETWORK_CFG.CHANNEL_MANAGER_ADDRESS
     channel_manager = make_channel_manager(private_key, contract_address, state_filename, web3)
     proxy = PaywalledProxy(channel_manager, flask_app, constants.HTML_DIR, constants.JSLIB_DIR)


### PR DESCRIPTION
1. `web3.eth.defaultAccount = privkey_to_addr(private_key)` - this is required in case of Infura, because otherwise web3 tries to request `coinbase` for some RPC calls to set a value for `from` field. If `defaultAccount` is set, then it uses that.
2. ~~`to_block=current_block + 100` - if this is missing, then web3 is setting `"pending"` as `toBlock` which Infura does not seem to like (returns empty results). Another way would be to force it somehow to not set this field, but I couldn't find how.~~
3. Some logging tweaks that came very handy while getting it to work. (Should be in a separate PR perhaps?)