### PR TITLE
Open/topUp by delegate (trusted) contracts

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -188,8 +188,8 @@ contract RaidenMicroTransferChannels {
         address _sender_address,
         address _receiver_address,
         uint192 _deposit)
-        external
         isTrustedContract
+        external
     {
         createChannelPrivate(_sender_address, _receiver_address, _deposit);
 
@@ -234,8 +234,8 @@ contract RaidenMicroTransferChannels {
         address _receiver_address,
         uint32 _open_block_number,
         uint192 _added_deposit)
-        external
         isTrustedContract
+        external
     {
         updateInternalBalanceStructs(
             _sender_address,

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -29,6 +29,7 @@ contract RaidenMicroTransferChannels {
 
     mapping (bytes32 => Channel) public channels;
     mapping (bytes32 => ClosingRequest) public closing_requests;
+    mapping (address => bool) public trusted_contracts;
 
     // 24 bytes (deposit) + 4 bytes (block number)
     struct Channel {
@@ -86,7 +87,12 @@ contract RaidenMicroTransferChannels {
     /// @param _challenge_period A fixed number of blocks representing the challenge period.
     /// We enforce a minimum of 500 blocks waiting period.
     /// after a sender requests the closing of the channel without the receiver's signature.
-    function RaidenMicroTransferChannels(address _token_address, uint32 _challenge_period) public {
+    function RaidenMicroTransferChannels(
+        address _token_address,
+        uint32 _challenge_period,
+        address[] _trusted_contracts)
+        public
+    {
         require(_token_address != 0x0);
         require(addressHasCode(_token_address));
         require(_challenge_period >= 500);
@@ -97,6 +103,11 @@ contract RaidenMicroTransferChannels {
         require(token.totalSupply() > 0);
 
         challenge_period = _challenge_period;
+        for (uint256 i = 0; i < _trusted_contracts.length; i++) {
+            require(_trusted_contracts[i] != 0x0);
+            require(addressHasCode(_trusted_contracts[i]));
+            trusted_contracts[_trusted_contracts[i]] = true;
+        }
     }
 
     /*
@@ -105,9 +116,10 @@ contract RaidenMicroTransferChannels {
 
     /// @notice Opens a new channel or tops up an existing one, compatibility with ERC 223.
     /// @dev Can only be called from the trusted Token contract.
-    /// @param _sender_address The address that sends the tokens.
+    /// @param _sender_address The address that sent the tokens to this contract.
     /// @param _deposit The amount of tokens that the sender escrows.
-    /// @param _data Receiver address in bytes.
+    /// @param _data Data needed for either creating a channel or topping it up.
+    /// It always contains the sender and receiver addresses +/- a block number.
     function tokenFallback(address _sender_address, uint256 _deposit, bytes _data) external {
         // Make sure we trust the token
         require(msg.sender == address(token));
@@ -115,21 +127,28 @@ contract RaidenMicroTransferChannels {
         uint192 deposit = uint192(_deposit);
         require(deposit == _deposit);
 
+        // Create channel - sender address + receiver address = 2 * 20 bytes
+        // Top up channel - sender address + receiver address + block number = 2 * 20 + 4 bytes
         uint length = _data.length;
+        require(length == 40 || length == 44);
 
-        // createChannel - receiver address (20 bytes)
-        // topUp - receiver address (20 bytes) + open_block_number (4 bytes) = 24 bytes
-        require(length == 20 || length == 24);
+        // Offset of 32 bytes, representing data.length
+        address channel_sender_address = address(addressFromBytes(_data, 0x20));
 
-        address receiver = addressFromData(_data);
+        // The channel can be opened by the sender or by a trusted contract
+        require(_sender_address == channel_sender_address || trusted_contracts[_sender_address]);
 
-        if(length == 20) {
-            createChannelPrivate(_sender_address, receiver, deposit);
+        // Offset of 32 bytes (data.length) + 20 bytes (sender address)
+        address channel_receiver_address = address(addressFromBytes(_data, 0x34));
+
+        if (length == 40) {
+            createChannelPrivate(channel_sender_address, channel_receiver_address, deposit);
         } else {
-            uint32 open_block_number = blockNumberFromData(_data);
+            // Offset of 32 bytes (data.length) + 20 bytes (sender address) + 20 bytes (receiver address)
+            uint32 open_block_number = uint32(blockNumberFromBytes(_data, 0x48));
             updateInternalBalanceStructs(
-                _sender_address,
-                receiver,
+                channel_sender_address,
+                channel_receiver_address,
                 open_block_number,
                 deposit
             );
@@ -140,11 +159,31 @@ contract RaidenMicroTransferChannels {
     /// the `_deposit` token deposit to this contract, compatibility with ERC20 tokens.
     /// @param _receiver_address The address that receives tokens.
     /// @param _deposit The amount of tokens that the sender escrows.
-    function createChannelERC20(address _receiver_address, uint192 _deposit) external {
+    function createChannel(address _receiver_address, uint192 _deposit) external {
         createChannelPrivate(msg.sender, _receiver_address, _deposit);
 
-        // transferFrom deposit from sender to contract
-        // ! needs prior approval from user
+        // transferFrom deposit from msg.sender to contract
+        // ! needs prior approval from msg.sender
+        require(token.transferFrom(msg.sender, address(this), _deposit));
+    }
+
+    /// @notice Function that allows a trusted contract to create a new channel between `_sender_address` and `_receiver_address` and transfers
+    /// the `_deposit` token deposit to this contract, compatibility with ERC20 tokens.
+    /// @param _sender_address The sender's address in behalf of whom the delegate sends tokens.
+    /// @param _receiver_address The address that receives tokens.
+    /// @param _deposit The amount of tokens that the sender escrows.
+    function createChannelDelegate(
+        address _sender_address,
+        address _receiver_address,
+        uint192 _deposit)
+        external
+    {
+        require(trusted_contracts[msg.sender]);
+
+        createChannelPrivate(_sender_address, _receiver_address, _deposit);
+
+        // transferFrom deposit from msg.sender to contract
+        // ! needs prior approval from msg.sender
         require(token.transferFrom(msg.sender, address(this), _deposit));
     }
 
@@ -153,7 +192,7 @@ contract RaidenMicroTransferChannels {
     /// @param _open_block_number The block number at which a channel between the
     /// sender and receiver was created.
     /// @param _added_deposit The added token deposit with which the current deposit is increased.
-    function topUpERC20(
+    function topUp(
         address _receiver_address,
         uint32 _open_block_number,
         uint192 _added_deposit)
@@ -161,6 +200,34 @@ contract RaidenMicroTransferChannels {
     {
         updateInternalBalanceStructs(
             msg.sender,
+            _receiver_address,
+            _open_block_number,
+            _added_deposit
+        );
+
+        // transferFrom deposit from msg.sender to contract
+        // ! needs prior approval from user
+        // Do transfer after any state change
+        require(token.transferFrom(msg.sender, address(this), _added_deposit));
+    }
+
+    /// @notice Increase the channel deposit with `_added_deposit`.
+    /// @param _sender_address The sender's address in behalf of whom the delegate sends tokens.
+    /// @param _receiver_address The address that receives tokens.
+    /// @param _open_block_number The block number at which a channel between the
+    /// sender and receiver was created.
+    /// @param _added_deposit The added token deposit with which the current deposit is increased.
+    function topUpDelegate(
+        address _sender_address,
+        address _receiver_address,
+        uint32 _open_block_number,
+        uint192 _added_deposit)
+        external
+    {
+        require(trusted_contracts[msg.sender]);
+
+        updateInternalBalanceStructs(
+            _sender_address,
             _receiver_address,
             _open_block_number,
             _added_deposit
@@ -472,27 +539,25 @@ contract RaidenMicroTransferChannels {
      */
 
     /// @dev Internal function for getting an address from tokenFallback data bytes.
-    /// @param b Bytes received.
-    /// @return Address resulted.
-    function addressFromData (bytes b) internal pure returns (address) {
-        bytes20 addr;
+    /// @param data Bytes received.
+    /// @param offset Number of bytes to offset.
+    /// @return Extracted address.
+    function addressFromBytes (bytes data, uint256 offset) internal pure returns (address) {
+        bytes20 extracted_address;
         assembly {
-            // Read address bytes
-            // Offset of 32 bytes, representing b.length
-            addr := mload(add(b, 0x20))
+            extracted_address := mload(add(data, offset))
         }
-        return address(addr);
+        return address(extracted_address);
     }
 
     /// @dev Internal function for getting the block number from tokenFallback data bytes.
-    /// @param b Bytes received.
+    /// @param data Bytes received.
+    /// @param offset Number of bytes to offset.
     /// @return Block number.
-    function blockNumberFromData(bytes b) internal pure returns (uint32) {
+    function blockNumberFromBytes(bytes data, uint256 offset) internal pure returns (uint32) {
         bytes4 block_number;
         assembly {
-            // Read block number bytes
-            // Offset of 32 bytes (b.length) + 20 bytes (address)
-            block_number := mload(add(b, 0x34))
+            block_number := mload(add(data, offset))
         }
         return uint32(block_number);
     }

--- a/contracts/contracts/test/Delegate.sol
+++ b/contracts/contracts/test/Delegate.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.17;
+
+import '../RaidenMicroTransferChannels.sol';
+import '../Token.sol';
+
+/*
+ * This is a contract used for testing RaidenMicroTransferChannels.
+ */
+
+contract Delegate {
+
+    RaidenMicroTransferChannels public microraiden;
+    Token public token;
+
+    function setup(address _token_address, address _microraiden_contract) external {
+        require(_microraiden_contract != 0x0);
+        require(_token_address != 0x0);
+        microraiden = RaidenMicroTransferChannels(_microraiden_contract);
+        token = Token(_token_address);
+    }
+
+    function createChannelERC20(address _sender_address, address _receiver_address, uint192 _deposit) external {
+        token.approve(address(microraiden), _deposit);
+        microraiden.createChannelDelegate(_sender_address, _receiver_address, _deposit);
+    }
+
+    function createChannelERC223(uint192 _deposit, bytes _data) external {
+        token.transfer(address(microraiden), _deposit, _data);
+    }
+
+    function topUpERC20(address _sender_address, address _receiver_address, uint32 _open_block_number, uint192 _deposit) external {
+        token.approve(address(microraiden), _deposit);
+        microraiden.topUpDelegate(_sender_address, _receiver_address, _open_block_number, _deposit);
+    }
+
+    function topUpERC223(uint192 _deposit, bytes _data) external {
+        token.transfer(address(microraiden), _deposit, _data);
+    }
+}

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -51,7 +51,8 @@ uraiden_events = {
     'created': 'ChannelCreated',
     'topup': 'ChannelToppedUp',
     'closed': 'ChannelCloseRequested',
-    'settled': 'ChannelSettled'
+    'settled': 'ChannelSettled',
+    'trusted': 'TrustedContract'
 }
 
 

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -210,3 +210,10 @@ def checkSettledEvent(sender, receiver, open_block_number, balance):
         assert event['args']['_open_block_number'] == open_block_number
         assert event['args']['_balance'] == balance
     return get
+
+
+def checkTrustedEvent(contract_address, trusted_status):
+    def get(event):
+        assert event['args']['_trusted_contract_address'] == contract_address
+        assert event['args']['_trusted_status'] == trusted_status
+    return get

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -55,21 +55,42 @@ def token_instance(token_contract):
     return token_contract()
 
 
+@pytest.fixture()
+def delegate_contract(chain, owner, create_contract):
+    def get(transaction=None):
+        Delegate = chain.provider.get_contract_factory('Delegate')
+        delegate_contract = create_contract(Delegate, [], {})
+        return delegate_contract
+    return get
+
+
+@pytest.fixture()
+def delegate_instance(delegate_contract):
+    return delegate_contract()
+
+
 @pytest.fixture
 def uraiden_contract(contract_params, token_instance, get_uraiden_contract):
-    def get(token=None, transaction=None):
+    def get(token=None, trusted_contracts=[], transaction=None):
         if not token:
             token = token_instance
         uraiden_contract = get_uraiden_contract(
-            [token.address, contract_params['challenge_period']]
+            [token.address, contract_params['challenge_period'], trusted_contracts]
         )
         return uraiden_contract
     return get
 
 
 @pytest.fixture
-def uraiden_instance(owner, uraiden_contract):
-    uraiden_instance = uraiden_contract()
+def uraiden_instance(owner, uraiden_contract, token_instance, delegate_instance):
+    uraiden_instance = uraiden_contract(
+        token_instance,
+        [delegate_instance.address]
+    )
+    delegate_instance.transact({'from': owner}).setup(
+        token_instance.address,
+        uraiden_instance.address
+    )
     return uraiden_instance
 
 
@@ -95,12 +116,12 @@ def get_channel(channel_params, owner, get_accounts, uraiden_instance, token_ins
                 uraiden.address,
                 deposit
             )
-            txn_hash = uraiden.transact({"from": sender}).createChannelERC20(
+            txn_hash = uraiden.transact({"from": sender}).createChannel(
                 receiver,
                 deposit
             )
         else:
-            txdata = bytes.fromhex(receiver[2:].zfill(40))
+            txdata = bytes.fromhex(sender[2:] + receiver[2:])
             txn_hash = token.transact({"from": sender}).transfer(
                 uraiden.address,
                 deposit,
@@ -137,7 +158,7 @@ def channel_settle_tests(uraiden_instance, token, channel):
     # token.transact({"from": sender}).approve(uraiden_instance.address, 33)
 
     with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({'from': sender}).topUpERC20(receiver, open_block_number, 33)
+        uraiden_instance.transact({'from': sender}).topUp(receiver, open_block_number, 33)
 
 
 def channel_pre_close_tests(uraiden_instance, token, channel, top_up_deposit=0):
@@ -149,7 +170,7 @@ def channel_pre_close_tests(uraiden_instance, token, channel, top_up_deposit=0):
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({'from': sender}).settle(receiver, open_block_number)
 
-    uraiden_instance.transact({'from': sender}).topUpERC20(
+    uraiden_instance.transact({'from': sender}).topUp(
         receiver,
         open_block_number,
         top_up_deposit

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -27,6 +27,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    delegate_contract,
+    delegate_instance,
     get_channel,
     channel_settle_tests,
     channel_pre_close_tests,
@@ -185,7 +187,7 @@ def test_uncooperative_close_fail_uint32_overflow(
         get_channel):
     challenge_period = MAX_UINT32 - 20
     uraiden_instance = get_uraiden_contract(
-        [token_instance.address, challenge_period]
+        [token_instance.address, challenge_period, []]
     )
 
     (sender, receiver, open_block_number) = get_channel(uraiden_instance)[:3]
@@ -211,7 +213,7 @@ def test_uncooperative_close_uint32_overflow(
         get_channel):
     challenge_period = MAX_UINT32 - 20
     uraiden_instance = get_uraiden_contract(
-        [token_instance.address, challenge_period]
+        [token_instance.address, challenge_period, []]
     )
 
     (sender, receiver, open_block_number) = get_channel(uraiden_instance)[:3]

--- a/contracts/tests/test_channel_delegate.py
+++ b/contracts/tests/test_channel_delegate.py
@@ -1,0 +1,145 @@
+import pytest
+from ethereum import tester
+from tests.fixtures import (
+    contract_params,
+    channel_params,
+    owner_index,
+    owner,
+    create_accounts,
+    get_accounts,
+    create_contract,
+    get_token_contract,
+    get_block,
+    fake_address,
+    empty_address,
+)
+from tests.fixtures_uraiden import (
+    token_contract,
+    token_instance,
+    get_uraiden_contract,
+    uraiden_contract,
+    uraiden_instance,
+    delegate_contract,
+    delegate_instance,
+    get_channel,
+)
+
+
+def test_channel_erc223_create_delegate(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        delegate_instance,
+        get_block):
+    (sender, receiver) = get_accounts(2)
+    deposit = 1000
+    txdata = bytes.fromhex(sender[2:] + receiver[2:])
+
+    # Delegate contract is a trusted contract
+    assert uraiden_instance.call().trusted_contracts(delegate_instance.address)
+
+    # Fund delegate contract with tokens
+    token_instance.transact({"from": owner}).transfer(delegate_instance.address, deposit + 100)
+
+    # Create channel through delegate
+    txn_hash = delegate_instance.transact({"from": sender}).createChannelERC223(deposit, txdata)
+
+    # Make sure the channel was created between sender and receiver
+    open_block_number = get_block(txn_hash)
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[0] == uraiden_instance.call().getKey(
+        sender,
+        receiver,
+        open_block_number
+    )
+    assert channel_data[1] == deposit
+    assert channel_data[2] == 0
+    assert channel_data[3] == 0
+
+
+def test_channel_erc20_create_delegate(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        delegate_instance,
+        get_block):
+    (sender, receiver) = get_accounts(2)
+    deposit = 1000
+
+    # Delegate contract is a trusted contract
+    assert uraiden_instance.call().trusted_contracts(delegate_instance.address)
+
+    # Fund delegate with tokens
+    token_instance.transact({"from": owner}).transfer(delegate_instance.address, deposit + 100)
+
+    # Create channel through delegate
+    txn_hash = delegate_instance.transact({"from": sender}).createChannelERC20(sender, receiver, deposit)
+
+    # Make sure the channel was created between sender and receiver
+    open_block_number = get_block(txn_hash)
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[0] == uraiden_instance.call().getKey(
+        sender,
+        receiver,
+        open_block_number
+    )
+    assert channel_data[1] == deposit
+    assert channel_data[2] == 0
+    assert channel_data[3] == 0
+
+
+def test_channel_erc223_topup_delegate(
+        owner,
+        uraiden_instance,
+        token_instance,
+        delegate_instance,
+        get_channel):
+    deposit = 1000
+    deposit_topup = 200
+    (sender, receiver, open_block_number) = get_channel(uraiden_instance, token_instance, deposit)[:3]
+    txdata = sender[2:] + receiver[2:] + hex(open_block_number)[2:].zfill(8)
+    txdata = bytes.fromhex(txdata)
+
+    # Delegate contract is a trusted contract
+    assert uraiden_instance.call().trusted_contracts(delegate_instance.address)
+
+    # Fund delegate with tokens
+    token_instance.transact({"from": owner}).transfer(delegate_instance.address, deposit_topup + 100)
+
+    # Top up channel through delegate
+    delegate_instance.transact({"from": sender}).topUpERC223(deposit_topup, txdata)
+
+    # Check channel deposit
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[1] == deposit + deposit_topup
+
+
+def test_channel_erc20_topup_delegate(
+        owner,
+        uraiden_instance,
+        token_instance,
+        delegate_instance,
+        get_channel):
+    deposit = 1000
+    deposit_topup = 200
+    (sender, receiver, open_block_number) = get_channel(uraiden_instance, token_instance, deposit)[:3]
+
+    # Delegate contract is a trusted contract
+    assert uraiden_instance.call().trusted_contracts(delegate_instance.address)
+
+    # Fund delegate with tokens
+    token_instance.transact({"from": owner}).transfer(delegate_instance.address, deposit_topup)
+
+    # Top up channel through delegate
+    delegate_instance.transact({"from": sender}).topUpERC20(
+        sender,
+        receiver,
+        open_block_number,
+        deposit_topup
+    )
+
+    # Check channel deposit
+    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_data[1] == deposit + deposit_topup

--- a/contracts/tests/test_channel_delegate.py
+++ b/contracts/tests/test_channel_delegate.py
@@ -143,3 +143,28 @@ def test_channel_erc20_topup_delegate(
     # Check channel deposit
     channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
     assert channel_data[1] == deposit + deposit_topup
+
+
+def test_delegate_remove_trusted_contract(
+        owner,
+        get_accounts,
+        uraiden_instance,
+        token_instance,
+        delegate_instance):
+    (sender, receiver) = get_accounts(2)
+    deposit = 1000
+
+    # Fund delegate with tokens
+    token_instance.transact({"from": owner}).transfer(delegate_instance.address, deposit * 3)
+
+    # Create channel through delegate
+    delegate_instance.transact({"from": sender}).createChannelERC20(sender, receiver, deposit)
+
+    # Remove trusted contract
+    uraiden_instance.transact({"from": owner}).removeTrustedContracts([
+        delegate_instance.address
+    ])
+
+    # Delegate create channel should fail now
+    with pytest.raises(tester.TransactionFailed):
+        delegate_instance.transact({"from": sender}).createChannelERC20(sender, receiver, deposit)

--- a/contracts/tests/test_ecverify.py
+++ b/contracts/tests/test_ecverify.py
@@ -17,6 +17,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    delegate_contract,
+    delegate_instance,
 )
 
 

--- a/contracts/tests/test_trusted_contracts.py
+++ b/contracts/tests/test_trusted_contracts.py
@@ -1,0 +1,228 @@
+import pytest
+from ethereum import tester
+from tests.fixtures import (
+    challenge_period_min,
+    contract_params,
+    channel_params,
+    owner_index,
+    owner,
+    create_accounts,
+    get_accounts,
+    create_contract,
+    get_token_contract,
+    fake_address,
+    empty_address,
+    event_handler,
+    print_gas,
+    txn_gas,
+    get_block,
+    uraiden_events,
+)
+from tests.fixtures_uraiden import (
+    token_contract,
+    token_instance,
+    get_uraiden_contract,
+    uraiden_contract,
+    uraiden_instance,
+    delegate_contract,
+    delegate_instance,
+    get_channel,
+    checkTrustedEvent
+)
+
+
+def test_trusted_contracts_constructor(
+        owner,
+        get_accounts,
+        get_uraiden_contract,
+        uraiden_contract,
+        token_instance,
+        delegate_contract,
+        contract_params):
+    trusted_contract = delegate_contract()
+    trusted_contract2 = delegate_contract()
+    other_contract = delegate_contract()
+    simple_account = get_accounts(1)[0]
+    uraiden = uraiden_contract(token_instance, [trusted_contract.address])
+
+    assert uraiden.call().trusted_contracts(trusted_contract.address)
+    assert not uraiden.call().trusted_contracts(other_contract.address)
+
+    with pytest.raises(TypeError):
+        get_uraiden_contract([token_instance.address, challenge_period_min])
+    with pytest.raises(TypeError):
+        get_uraiden_contract([token_instance.address, challenge_period_min, [fake_address]])
+
+    uraiden2 = get_uraiden_contract([
+        token_instance.address,
+        challenge_period_min,
+        [trusted_contract2.address, empty_address, simple_account]
+    ])
+    assert uraiden2.call().trusted_contracts(trusted_contract2.address)
+    assert not uraiden2.call().trusted_contracts(empty_address)
+    assert not uraiden2.call().trusted_contracts(simple_account)
+
+
+def test_add_trusted_contracts_call(owner, get_accounts, uraiden_instance, delegate_contract):
+    (A, B) = get_accounts(2)
+    trusted_contract = delegate_contract()
+
+    with pytest.raises(TypeError):
+        uraiden_instance.transact({'from': owner}).addTrustedContracts([fake_address])
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([])
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([empty_address])
+
+
+def test_add_trusted_contracts_only_owner(owner, get_accounts, uraiden_instance, delegate_contract):
+    (A, B) = get_accounts(2)
+    trusted_contract = delegate_contract()
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({'from': A}).addTrustedContracts([trusted_contract.address])
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([trusted_contract.address])
+    assert uraiden_instance.call().trusted_contracts(trusted_contract.address)
+
+
+def test_add_trusted_contracts_state(owner, get_accounts, uraiden_instance, delegate_contract, print_gas):
+    (A, B) = get_accounts(2)
+    trusted_contract1 = delegate_contract()
+    trusted_contract2 = delegate_contract()
+    trusted_contract3 = delegate_contract()
+    trusted_contract4 = delegate_contract()
+
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract1.address)
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract2.address)
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract3.address)
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract4.address)
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([A])
+    assert not uraiden_instance.call().trusted_contracts(A)
+
+    txn_hash = uraiden_instance.transact({'from': owner}).addTrustedContracts([trusted_contract1.address])
+    assert uraiden_instance.call().trusted_contracts(trusted_contract1.address)
+
+    print_gas(txn_hash, 'add 1 trusted contract')
+
+    txn_hash = uraiden_instance.transact({'from': owner}).addTrustedContracts([
+        trusted_contract2.address,
+        trusted_contract3.address,
+        A,
+        trusted_contract4.address
+    ])
+    assert uraiden_instance.call().trusted_contracts(trusted_contract2.address)
+    assert uraiden_instance.call().trusted_contracts(trusted_contract3.address)
+    assert uraiden_instance.call().trusted_contracts(trusted_contract4.address)
+    assert not uraiden_instance.call().trusted_contracts(A)
+
+    print_gas(txn_hash, 'add 3 trusted contracts')
+
+
+def test_add_trusted_contracts_event(owner, get_accounts, uraiden_instance, delegate_contract, event_handler):
+    (A, B) = get_accounts(2)
+    ev_handler = event_handler(uraiden_instance)
+    trusted_contract = delegate_contract()
+
+    txn_hash = uraiden_instance.transact({'from': owner}).addTrustedContracts(
+        [trusted_contract.address]
+    )
+
+    ev_handler.add(
+        txn_hash,
+        uraiden_events['trusted'],
+        checkTrustedEvent(trusted_contract.address, True)
+    )
+    ev_handler.check()
+
+
+def test_remove_trusted_contracts_call(owner, get_accounts, uraiden_instance, delegate_contract):
+    (A, B) = get_accounts(2)
+    trusted_contract1 = delegate_contract()
+    trusted_contract2 = delegate_contract()
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts(
+        [trusted_contract1.address, trusted_contract2.address]
+    )
+
+    with pytest.raises(TypeError):
+        uraiden_instance.transact({'from': owner}).removeTrustedContracts([fake_address])
+
+    uraiden_instance.transact({'from': owner}).removeTrustedContracts([])
+    uraiden_instance.transact({'from': owner}).removeTrustedContracts(
+        [empty_address, trusted_contract1.address]
+    )
+
+
+def test_remove_trusted_contracts_only_owner(owner, get_accounts, uraiden_instance, delegate_contract):
+    (A, B) = get_accounts(2)
+    trusted_contract = delegate_contract()
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([trusted_contract.address])
+    assert uraiden_instance.call().trusted_contracts(trusted_contract.address)
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({'from': A}).removeTrustedContracts([trusted_contract.address])
+
+    uraiden_instance.transact({'from': owner}).removeTrustedContracts(
+        [trusted_contract.address]
+    )
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract.address)
+
+
+def test_remove_trusted_contracts_state(owner, get_accounts, uraiden_instance, delegate_contract, print_gas):
+    (A, B) = get_accounts(2)
+    trusted_contract1 = delegate_contract()
+    trusted_contract2 = delegate_contract()
+    trusted_contract3 = delegate_contract()
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts([
+        trusted_contract1.address,
+        trusted_contract2.address,
+        trusted_contract3.address
+    ])
+
+    assert uraiden_instance.call().trusted_contracts(trusted_contract1.address)
+    assert uraiden_instance.call().trusted_contracts(trusted_contract2.address)
+    assert uraiden_instance.call().trusted_contracts(trusted_contract3.address)
+
+    txn_hash = uraiden_instance.transact({'from': owner}).removeTrustedContracts([
+        trusted_contract1.address,
+        trusted_contract2.address,
+        A
+    ])
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract1.address)
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract2.address)
+    assert uraiden_instance.call().trusted_contracts(trusted_contract3.address)
+
+    print_gas(txn_hash, 'remove 3 trusted contracts')
+
+    txn_hash = uraiden_instance.transact({'from': owner}).removeTrustedContracts([
+        trusted_contract3.address
+    ])
+
+    assert not uraiden_instance.call().trusted_contracts(trusted_contract3.address)
+
+    print_gas(txn_hash, 'remove 1 trusted contract')
+
+
+def test_remove_trusted_contracts_event(owner, get_accounts, uraiden_instance, delegate_contract, event_handler):
+    (A, B) = get_accounts(2)
+    ev_handler = event_handler(uraiden_instance)
+    trusted_contract1 = delegate_contract()
+    trusted_contract2 = delegate_contract()
+
+    uraiden_instance.transact({'from': owner}).addTrustedContracts(
+        [trusted_contract1.address, trusted_contract2.address]
+    )
+
+    txn_hash = uraiden_instance.transact({'from': owner}).removeTrustedContracts(
+        [trusted_contract1.address]
+    )
+
+    ev_handler.add(
+        txn_hash,
+        uraiden_events['trusted'],
+        checkTrustedEvent(trusted_contract1.address, False)
+    )
+    ev_handler.check()

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from ethereum import tester
 from tests.fixtures import (
     channel_deposit_bugbounty_limit,
@@ -29,7 +28,6 @@ from tests.fixtures_uraiden import (
     delegate_instance,
     get_channel
 )
-# from tests.test_channel_create import get_channel
 
 
 def test_uraiden_init(
@@ -67,6 +65,7 @@ def test_uraiden_init(
         get_uraiden_contract([fake_token.address, challenge_period_min, []])
 
     uraiden = get_uraiden_contract([token.address, 2 ** 32 - 1, []])
+    assert uraiden.call().owner_address() == owner
     assert uraiden.call().token() == token.address
     assert uraiden.call().challenge_period() == 2 ** 32 - 1
     assert token.call().balanceOf(uraiden.address) == 0
@@ -78,6 +77,7 @@ def test_uraiden_init(
 
 def test_variable_access(owner, uraiden_contract, token_instance, contract_params):
     uraiden = uraiden_contract(token_instance)
+    assert uraiden.call().owner_address() == owner
     assert uraiden.call().token() == token_instance.address
     assert uraiden.call().challenge_period() == contract_params['challenge_period']
     assert uraiden.call().version() == uraiden_contract_version
@@ -142,32 +142,6 @@ def test_version(
     )
 
     assert uraiden_instance.call().version() == uraiden_contract_version
-
-
-def test_trusted_contracts(
-        owner,
-        get_accounts,
-        get_uraiden_contract,
-        uraiden_contract,
-        token_instance,
-        delegate_contract,
-        contract_params):
-    trusted_contract = delegate_contract()
-    other_contract = delegate_contract()
-    simple_account = get_accounts(1)[0]
-    uraiden = uraiden_contract(token_instance, [trusted_contract.address])
-
-    assert uraiden.call().trusted_contracts(trusted_contract.address)
-    assert uraiden.call().trusted_contracts(other_contract.address) == False
-
-    with pytest.raises(TypeError):
-        get_uraiden_contract([token_instance.address, challenge_period_min])
-    with pytest.raises(TypeError):
-        get_uraiden_contract([token_instance.address, challenge_period_min, [fake_address]])
-    with pytest.raises(tester.TransactionFailed):
-        get_uraiden_contract([token_instance.address, challenge_period_min, [empty_address]])
-    with pytest.raises(tester.TransactionFailed):
-        get_uraiden_contract([token_instance.address, challenge_period_min, [simple_account]])
 
 
 def test_get_channel_info(web3, get_accounts, uraiden_instance, token_instance, get_channel):


### PR DESCRIPTION
closes https://github.com/raiden-network/microraiden/issues/147

- `trusted_contracts` array - passed as a contract constructor argument.
- add `addTrustedContracts` only callable by `owner_address`
  - gas used for adding 1 trusted contract: `46888`
  - gas used for adding 3 trusted contracts: `97644`
- add `removeTrustedContracts` only callable by `owner_address`
  - gas used for adding 1 trusted contract: `16232`
  - gas used for adding 3 trusted contracts: `20964`
- add event `TrustedContract(address indexed _trusted_contract_address, bool _trusted_status)`
- a trusted contract can send tokens and open & top up channels in behalf of a `sender` (support for both ERC20 & ERC223 contracts)
  - `_data` argument from `tokenFallback` now has to contain:
```py
# create channel
sender_address (20 bytes) + receiver_address (20 bytes)
# top up
sender_address (20 bytes) + receiver_address (20 bytes) + open_block_number (4 bytes)
```
  - rename ERC20 compatible functions to `createChannel` , `topUp`
  - add ERC20 compatible functions: `createChannelDelegate`, `topUpDelegate`