### PR TITLE
Allow receiver to withdraw tokens without closing channel

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -291,7 +291,9 @@ contract RaidenMicroTransferChannels {
     /// @notice Allows channel receiver to withdraw tokens.
     /// @param _open_block_number The block number at which a channel between the
     /// sender and receiver was created.
-    /// @param _balance The amount of tokens owed by the sender to the receiver.
+    /// @param _balance Partial or total amount of tokens owed by the sender to the receiver.
+    /// Has to be smaller or equal to the channel deposit. Has to match the balance value from
+    /// `_balance_msg_sig` - the balance message signed by the sender.
     /// Has to be smaller or equal to the channel deposit.
     /// @param _balance_msg_sig The balance message signed by the sender.
     function withdraw(

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -285,6 +285,7 @@ contract RaidenMicroTransferChannels {
         // ! needs prior approval from the trusted contract
         // Do transfer after any state change
         require(token.transferFrom(msg.sender, address(this), _added_deposit));
+    }
 
     /// @notice Allows channel receiver to withdraw tokens.
     /// @param _open_block_number The block number at which a channel between the

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -313,6 +313,7 @@ contract RaidenMicroTransferChannels {
         require(channels[key].open_block_number > 0);
         require(closing_requests[key].settle_block_number == 0);
         require(_balance <= channels[key].deposit);
+        require(withdrawn_balances[key] < _balance);
 
         uint192 remaining_balance = _balance - withdrawn_balances[key];
         withdrawn_balances[key] = _balance;

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -93,7 +93,8 @@ contract RaidenMicroTransferChannels {
         address indexed _sender,
         address indexed _receiver,
         uint32 indexed _open_block_number,
-        uint192 _balance);
+        uint192 _balance,
+        uint192 _receiver_tokens);
     event ChannelWithdraw(
         address indexed _sender,
         address indexed _receiver,
@@ -613,12 +614,19 @@ contract RaidenMicroTransferChannels {
         delete closing_requests[key];
 
         // Send _balance to the receiver, as it is always <= deposit
-        require(token.transfer(_receiver_address, _balance - withdrawn_balances[key]));
+        uint192 receiver_remaining_tokens = _balance - withdrawn_balances[key];
+        require(token.transfer(_receiver_address, receiver_remaining_tokens));
 
         // Send deposit - balance back to sender
         require(token.transfer(_sender_address, channel.deposit - _balance));
 
-        ChannelSettled(_sender_address, _receiver_address, _open_block_number, _balance);
+        ChannelSettled(
+            _sender_address,
+            _receiver_address,
+            _open_block_number,
+            _balance,
+            receiver_remaining_tokens
+        );
     }
 
     /*

--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -573,12 +573,12 @@ contract RaidenMicroTransferChannels {
 
         bytes32 key = getKey(_sender_address, _receiver_address, _open_block_number);
 
-        require(channels[key].deposit > 0);
+        require(channels[key].open_block_number > 0);
         require(closing_requests[key].settle_block_number == 0);
         require(channels[key].deposit + _added_deposit <= channel_deposit_bugbounty_limit);
 
         channels[key].deposit += _added_deposit;
-        assert(channels[key].deposit > _added_deposit);
+        assert(channels[key].deposit >= _added_deposit);
         ChannelToppedUp(_sender_address, _receiver_address, _open_block_number, _added_deposit);
     }
 

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -52,6 +52,7 @@ uraiden_events = {
     'topup': 'ChannelToppedUp',
     'closed': 'ChannelCloseRequested',
     'settled': 'ChannelSettled',
+    'withdraw': 'ChannelWithdraw',
     'trusted': 'TrustedContract'
 }
 

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -204,12 +204,13 @@ def checkClosedEvent(sender, receiver, open_block_number, balance):
     return get
 
 
-def checkSettledEvent(sender, receiver, open_block_number, balance):
+def checkSettledEvent(sender, receiver, open_block_number, balance, receiver_tokens):
     def get(event):
         assert event['args']['_sender'] == sender
         assert event['args']['_receiver'] == receiver
         assert event['args']['_open_block_number'] == open_block_number
         assert event['args']['_balance'] == balance
+        assert event['args']['_receiver_tokens'] == receiver_tokens
     return get
 
 

--- a/contracts/tests/fixtures_uraiden.py
+++ b/contracts/tests/fixtures_uraiden.py
@@ -36,6 +36,7 @@ def get_uraiden_contract(chain, create_contract):
             print_logs(uraiden_contract, 'ChannelToppedUp', 'RaidenMicroTransferChannels')
             print_logs(uraiden_contract, 'ChannelCloseRequested', 'RaidenMicroTransferChannels')
             print_logs(uraiden_contract, 'ChannelSettled', 'RaidenMicroTransferChannels')
+            print_logs(uraiden_contract, 'ChannelWithdraw', 'RaidenMicroTransferChannels')
 
         return uraiden_contract
     return get
@@ -216,4 +217,13 @@ def checkTrustedEvent(contract_address, trusted_status):
     def get(event):
         assert event['args']['_trusted_contract_address'] == contract_address
         assert event['args']['_trusted_status'] == trusted_status
+    return get
+
+
+def checkWithdrawEvent(sender, receiver, open_block_number, withdrawn_balance):
+    def get(event):
+        assert event['args']['_sender'] == sender
+        assert event['args']['_receiver'] == receiver
+        assert event['args']['_open_block_number'] == open_block_number
+        assert event['args']['_withdrawn_balance'] == withdrawn_balance
     return get

--- a/contracts/tests/test_channel_close.py
+++ b/contracts/tests/test_channel_close.py
@@ -862,6 +862,7 @@ def test_settle_event(
         sender,
         receiver,
         open_block_number,
+        balance,
         balance)
     )
     ev_handler.check()

--- a/contracts/tests/test_channel_withdraw.py
+++ b/contracts/tests/test_channel_withdraw.py
@@ -1,0 +1,357 @@
+import pytest
+from ethereum import tester
+from utils import sign
+from tests.utils import balance_proof_hash, closing_message_hash
+from tests.fixtures import (
+    contract_params,
+    channel_params,
+    owner_index,
+    owner,
+    create_accounts,
+    get_accounts,
+    create_contract,
+    get_token_contract,
+    txn_gas,
+    print_gas,
+    get_block,
+    event_handler,
+    fake_address,
+    MAX_UINT256,
+    MAX_UINT32,
+    MAX_UINT192,
+    uraiden_events
+)
+from tests.fixtures_uraiden import (
+    token_contract,
+    token_instance,
+    get_uraiden_contract,
+    uraiden_contract,
+    uraiden_instance,
+    get_channel,
+    checkWithdrawEvent
+)
+
+
+def test_withdraw_call(channel_params, uraiden_instance, get_channel):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    withdraw_balance = 30
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    with pytest.raises(TypeError):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            -2,
+            withdraw_balance,
+            balance_msg_sig
+        )
+    with pytest.raises(TypeError):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            MAX_UINT32 + 1,
+            withdraw_balance,
+            balance_msg_sig
+        )
+    with pytest.raises(TypeError):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            -1,
+            balance_msg_sig
+        )
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            withdraw_balance,
+            bytearray()
+        )
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            0,
+            balance_msg_sig
+        )
+
+    uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance,
+        balance_msg_sig
+    )
+
+
+def test_withdraw_fail_no_channel(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
+    A = get_accounts(1, 5)[0]
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    withdraw_balance = 10
+
+    balance_message_hash_A = balance_proof_hash(
+        A,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig_A, addr = sign.check(balance_message_hash_A, tester.k5)
+    assert addr == A
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": sender}).withdraw(
+            open_block_number,
+            withdraw_balance,
+            balance_msg_sig
+        )
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": A}).withdraw(
+            open_block_number,
+            withdraw_balance,
+            balance_msg_sig
+        )
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            withdraw_balance,
+            balance_msg_sig_A
+        )
+
+
+def test_withdraw_balance(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    withdraw_balance_ok = channel_params['deposit']
+    withdraw_balance_big = channel_params['deposit'] + 1
+
+    balance_message_hash_big = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance_big,
+        uraiden_instance.address
+    )
+    balance_msg_sig_big, addr = sign.check(balance_message_hash_big, tester.k2)
+    assert addr == sender
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance_ok,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            withdraw_balance_big,
+            balance_msg_sig_big
+        )
+
+    uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance_ok,
+        balance_msg_sig
+    )
+
+
+def test_withdraw_fail_in_challenge_period(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    withdraw_balance = 30
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    # Should fail if the channel is already in a challenge period
+    uraiden_instance.transact({"from": sender}).uncooperativeClose(
+        receiver,
+        open_block_number,
+        withdraw_balance
+    )
+
+    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    assert channel_info[2] > 0  # settle_block_number
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            withdraw_balance,
+            balance_msg_sig
+        )
+
+
+def test_withdraw_topup(owner, uraiden_instance, token_instance, get_channel):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    deposit = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)[1]
+    withdraw_balance = deposit
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance,
+        balance_msg_sig
+    )
+
+    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    deposit -= withdraw_balance
+    assert channel_info[1] == deposit
+
+    # Make sure we can top up the channel after withdrawal
+    top_up_deposit = 300
+    top_up_data = receiver[2:].zfill(40) + hex(open_block_number)[2:].zfill(8)
+    top_up_data = bytes.fromhex(top_up_data)
+
+    # Fund accounts with tokens
+    token_instance.transact({"from": owner}).transfer(sender, top_up_deposit)
+
+    # Top up channel
+    token_instance.transact({"from": sender}).transfer(uraiden_instance.address, top_up_deposit, top_up_data)
+
+    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    deposit += top_up_deposit
+    assert channel_info[1] == deposit
+
+
+def test_withdraw_state(
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        token_instance,
+        get_channel,
+        get_block,
+        print_gas):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    deposit = channel_params['deposit']
+    withdraw_balance1 = 20
+    withdraw_balance2 = deposit - 20
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance1,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    # Memorize balances for tests
+    uraiden_pre_balance = token_instance.call().balanceOf(uraiden_instance.address)
+    sender_pre_balance = token_instance.call().balanceOf(sender)
+    receiver_pre_balance = token_instance.call().balanceOf(receiver)
+
+    txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance1,
+        balance_msg_sig
+    )
+
+    # Check channel info
+    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    # deposit
+    assert channel_info[1] == deposit - withdraw_balance1
+    assert channel_info[2] == 0
+    assert channel_info[3] == 0
+
+    # Check token balances post withrawal
+    uraiden_balance = uraiden_pre_balance - withdraw_balance1
+    assert token_instance.call().balanceOf(uraiden_instance.address) == uraiden_balance
+    assert token_instance.call().balanceOf(sender) == sender_pre_balance
+    assert token_instance.call().balanceOf(receiver) == receiver_pre_balance + withdraw_balance1
+
+    print_gas(txn_hash, 'withdraw')
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance2,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance2,
+        balance_msg_sig
+    )
+
+    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
+    # deposit
+    assert channel_info[1] == 0
+    assert channel_info[2] == 0
+    assert channel_info[3] == 0
+
+    # Check token balances post withrawal
+    uraiden_balance = uraiden_pre_balance - deposit
+    assert token_instance.call().balanceOf(uraiden_instance.address) == uraiden_balance
+    assert token_instance.call().balanceOf(sender) == sender_pre_balance
+    assert token_instance.call().balanceOf(receiver) == receiver_pre_balance + deposit
+
+    print_gas(txn_hash, 'withdraw')
+
+
+def test_withdraw_event(
+        channel_params,
+        uraiden_instance,
+        get_channel,
+        event_handler):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    ev_handler = event_handler(uraiden_instance)
+    withdraw_balance = 30
+
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        withdraw_balance,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        withdraw_balance,
+        balance_msg_sig
+    )
+
+    ev_handler.add(txn_hash, uraiden_events['withdraw'], checkWithdrawEvent(
+        sender,
+        receiver,
+        open_block_number,
+        withdraw_balance)
+    )
+    ev_handler.check()

--- a/contracts/tests/test_channel_withdraw.py
+++ b/contracts/tests/test_channel_withdraw.py
@@ -27,6 +27,8 @@ from tests.fixtures_uraiden import (
     get_uraiden_contract,
     uraiden_contract,
     uraiden_instance,
+    delegate_contract,
+    delegate_instance,
     get_channel,
     checkWithdrawEvent
 )

--- a/contracts/tests/test_channel_withdraw.py
+++ b/contracts/tests/test_channel_withdraw.py
@@ -34,12 +34,12 @@ from tests.fixtures_uraiden import (
 
 def test_withdraw_call(channel_params, uraiden_instance, get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
-    withdraw_balance = 30
+    balance = 30
 
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance,
+        balance,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -48,13 +48,13 @@ def test_withdraw_call(channel_params, uraiden_instance, get_channel):
     with pytest.raises(TypeError):
         uraiden_instance.transact({"from": receiver}).withdraw(
             -2,
-            withdraw_balance,
+            balance,
             balance_msg_sig
         )
     with pytest.raises(TypeError):
         uraiden_instance.transact({"from": receiver}).withdraw(
             MAX_UINT32 + 1,
-            withdraw_balance,
+            balance,
             balance_msg_sig
         )
     with pytest.raises(TypeError):
@@ -66,7 +66,7 @@ def test_withdraw_call(channel_params, uraiden_instance, get_channel):
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": receiver}).withdraw(
             open_block_number,
-            withdraw_balance,
+            balance,
             bytearray()
         )
     with pytest.raises(tester.TransactionFailed):
@@ -78,7 +78,7 @@ def test_withdraw_call(channel_params, uraiden_instance, get_channel):
 
     uraiden_instance.transact({"from": receiver}).withdraw(
         open_block_number,
-        withdraw_balance,
+        balance,
         balance_msg_sig
     )
 
@@ -90,12 +90,12 @@ def test_withdraw_fail_no_channel(
         get_channel):
     A = get_accounts(1, 5)[0]
     (sender, receiver, open_block_number) = get_channel()[:3]
-    withdraw_balance = 10
+    balance = 10
 
     balance_message_hash_A = balance_proof_hash(
         A,
         open_block_number,
-        withdraw_balance,
+        balance,
         uraiden_instance.address
     )
     balance_msg_sig_A, addr = sign.check(balance_message_hash_A, tester.k5)
@@ -104,7 +104,7 @@ def test_withdraw_fail_no_channel(
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance,
+        balance,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -113,36 +113,36 @@ def test_withdraw_fail_no_channel(
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": sender}).withdraw(
             open_block_number,
-            withdraw_balance,
+            balance,
             balance_msg_sig
         )
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": A}).withdraw(
             open_block_number,
-            withdraw_balance,
+            balance,
             balance_msg_sig
         )
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": receiver}).withdraw(
             open_block_number,
-            withdraw_balance,
+            balance,
             balance_msg_sig_A
         )
 
 
-def test_withdraw_balance(
+def test_balance_big(
         channel_params,
         get_accounts,
         uraiden_instance,
         get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
-    withdraw_balance_ok = channel_params['deposit']
-    withdraw_balance_big = channel_params['deposit'] + 1
+    balance_ok = channel_params['deposit']
+    balance_big = channel_params['deposit'] + 1
 
     balance_message_hash_big = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance_big,
+        balance_big,
         uraiden_instance.address
     )
     balance_msg_sig_big, addr = sign.check(balance_message_hash_big, tester.k2)
@@ -151,7 +151,7 @@ def test_withdraw_balance(
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance_ok,
+        balance_ok,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -160,14 +160,71 @@ def test_withdraw_balance(
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": receiver}).withdraw(
             open_block_number,
-            withdraw_balance_big,
+            balance_big,
             balance_msg_sig_big
         )
 
     uraiden_instance.transact({"from": receiver}).withdraw(
         open_block_number,
-        withdraw_balance_ok,
+        balance_ok,
         balance_msg_sig
+    )
+
+
+def test_balance_remaining_big(
+        channel_params,
+        get_accounts,
+        uraiden_instance,
+        get_channel):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    balance1 = 30
+    balance2_big = channel_params['deposit'] + 1
+    balance2_ok = channel_params['deposit']
+
+    balance_message_hash1 = balance_proof_hash(
+        receiver,
+        open_block_number,
+        balance1,
+        uraiden_instance.address
+    )
+    balance_msg_sig1, addr = sign.check(balance_message_hash1, tester.k2)
+    assert addr == sender
+
+    balance_message_hash2_big = balance_proof_hash(
+        receiver,
+        open_block_number,
+        balance2_big,
+        uraiden_instance.address
+    )
+    balance_msg_sig2_big, addr = sign.check(balance_message_hash2_big, tester.k2)
+    assert addr == sender
+
+    balance_message_hash2_ok = balance_proof_hash(
+        receiver,
+        open_block_number,
+        balance2_ok,
+        uraiden_instance.address
+    )
+    balance_msg_sig2_ok, addr = sign.check(balance_message_hash2_ok, tester.k2)
+    assert addr == sender
+
+    uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        balance1,
+        balance_msg_sig1
+    )
+
+    with pytest.raises(tester.TransactionFailed):
+        uraiden_instance.transact({"from": receiver}).withdraw(
+            open_block_number,
+            balance2_big,
+            balance_msg_sig2_big
+        )
+
+    uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        balance2_ok,
+        balance_msg_sig2_ok
     )
 
 
@@ -177,12 +234,12 @@ def test_withdraw_fail_in_challenge_period(
         uraiden_instance,
         get_channel):
     (sender, receiver, open_block_number) = get_channel()[:3]
-    withdraw_balance = 30
+    balance = 30
 
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance,
+        balance,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -192,7 +249,7 @@ def test_withdraw_fail_in_challenge_period(
     uraiden_instance.transact({"from": sender}).uncooperativeClose(
         receiver,
         open_block_number,
-        withdraw_balance
+        balance
     )
 
     channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
@@ -201,49 +258,9 @@ def test_withdraw_fail_in_challenge_period(
     with pytest.raises(tester.TransactionFailed):
         uraiden_instance.transact({"from": receiver}).withdraw(
             open_block_number,
-            withdraw_balance,
+            balance,
             balance_msg_sig
         )
-
-
-def test_withdraw_topup(owner, uraiden_instance, token_instance, get_channel):
-    (sender, receiver, open_block_number) = get_channel()[:3]
-    deposit = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)[1]
-    withdraw_balance = deposit
-
-    balance_message_hash = balance_proof_hash(
-        receiver,
-        open_block_number,
-        withdraw_balance,
-        uraiden_instance.address
-    )
-    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
-    assert addr == sender
-
-    uraiden_instance.transact({"from": receiver}).withdraw(
-        open_block_number,
-        withdraw_balance,
-        balance_msg_sig
-    )
-
-    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    deposit -= withdraw_balance
-    assert channel_info[1] == deposit
-
-    # Make sure we can top up the channel after withdrawal
-    top_up_deposit = 300
-    top_up_data = receiver[2:].zfill(40) + hex(open_block_number)[2:].zfill(8)
-    top_up_data = bytes.fromhex(top_up_data)
-
-    # Fund accounts with tokens
-    token_instance.transact({"from": owner}).transfer(sender, top_up_deposit)
-
-    # Top up channel
-    token_instance.transact({"from": sender}).transfer(uraiden_instance.address, top_up_deposit, top_up_data)
-
-    channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    deposit += top_up_deposit
-    assert channel_info[1] == deposit
 
 
 def test_withdraw_state(
@@ -256,13 +273,13 @@ def test_withdraw_state(
         print_gas):
     (sender, receiver, open_block_number) = get_channel()[:3]
     deposit = channel_params['deposit']
-    withdraw_balance1 = 20
-    withdraw_balance2 = deposit - 20
+    balance1 = 20
+    balance2 = deposit
 
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance1,
+        balance1,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -275,29 +292,30 @@ def test_withdraw_state(
 
     txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
         open_block_number,
-        withdraw_balance1,
+        balance1,
         balance_msg_sig
     )
 
     # Check channel info
     channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
     # deposit
-    assert channel_info[1] == deposit - withdraw_balance1
+    assert channel_info[1] == deposit
     assert channel_info[2] == 0
     assert channel_info[3] == 0
+    assert channel_info[4] == balance1
 
     # Check token balances post withrawal
-    uraiden_balance = uraiden_pre_balance - withdraw_balance1
+    uraiden_balance = uraiden_pre_balance - balance1
     assert token_instance.call().balanceOf(uraiden_instance.address) == uraiden_balance
     assert token_instance.call().balanceOf(sender) == sender_pre_balance
-    assert token_instance.call().balanceOf(receiver) == receiver_pre_balance + withdraw_balance1
+    assert token_instance.call().balanceOf(receiver) == receiver_pre_balance + balance1
 
     print_gas(txn_hash, 'withdraw')
 
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance2,
+        balance2,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -305,15 +323,16 @@ def test_withdraw_state(
 
     txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
         open_block_number,
-        withdraw_balance2,
+        balance2,
         balance_msg_sig
     )
 
     channel_info = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
     # deposit
-    assert channel_info[1] == 0
+    assert channel_info[1] == deposit
     assert channel_info[2] == 0
     assert channel_info[3] == 0
+    assert channel_info[4] == balance2
 
     # Check token balances post withrawal
     uraiden_balance = uraiden_pre_balance - deposit
@@ -324,6 +343,76 @@ def test_withdraw_state(
     print_gas(txn_hash, 'withdraw')
 
 
+def test_close_after_withdraw(
+        contract_params,
+        channel_params,
+        uraiden_instance,
+        token_instance,
+        get_channel,
+        get_block,
+        print_gas):
+    (sender, receiver, open_block_number) = get_channel()[:3]
+    deposit = channel_params['deposit']
+    balance1 = 20
+    balance2 = deposit
+
+    balance_message_hash1 = balance_proof_hash(
+        receiver,
+        open_block_number,
+        balance1,
+        uraiden_instance.address
+    )
+    balance_msg_sig1, addr = sign.check(balance_message_hash1, tester.k2)
+    assert addr == sender
+
+    # Withdraw some tokens
+    txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
+        open_block_number,
+        balance1,
+        balance_msg_sig1
+    )
+
+    # Cooperatively close the channel
+    balance_message_hash = balance_proof_hash(
+        receiver,
+        open_block_number,
+        balance2,
+        uraiden_instance.address
+    )
+    balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
+    assert addr == sender
+
+    closing_msg_hash = closing_message_hash(
+        sender,
+        open_block_number,
+        balance2,
+        uraiden_instance.address
+    )
+    closing_sig, addr = sign.check(closing_msg_hash, tester.k3)
+
+    # Memorize balances for tests
+    uraiden_pre_balance = token_instance.call().balanceOf(uraiden_instance.address)
+    sender_pre_balance = token_instance.call().balanceOf(sender)
+    receiver_pre_balance = token_instance.call().balanceOf(receiver)
+
+    uraiden_instance.transact({"from": receiver}).cooperativeClose(
+        receiver,
+        open_block_number,
+        balance2,
+        balance_msg_sig,
+        closing_sig
+    )
+
+    # Check post closing balances
+    receiver_post_balance = receiver_pre_balance + (balance2 - balance1)
+    sender_post_balance = sender_pre_balance + (deposit - balance2)
+    uraiden_post_balance = uraiden_pre_balance - (balance2 - balance1)
+
+    assert token_instance.call().balanceOf(receiver) == receiver_post_balance
+    assert token_instance.call().balanceOf(sender) == sender_post_balance
+    assert token_instance.call().balanceOf(uraiden_instance.address) == uraiden_post_balance
+
+
 def test_withdraw_event(
         channel_params,
         uraiden_instance,
@@ -331,12 +420,12 @@ def test_withdraw_event(
         event_handler):
     (sender, receiver, open_block_number) = get_channel()[:3]
     ev_handler = event_handler(uraiden_instance)
-    withdraw_balance = 30
+    balance = 30
 
     balance_message_hash = balance_proof_hash(
         receiver,
         open_block_number,
-        withdraw_balance,
+        balance,
         uraiden_instance.address
     )
     balance_msg_sig, addr = sign.check(balance_message_hash, tester.k2)
@@ -344,7 +433,7 @@ def test_withdraw_event(
 
     txn_hash = uraiden_instance.transact({"from": receiver}).withdraw(
         open_block_number,
-        withdraw_balance,
+        balance,
         balance_msg_sig
     )
 
@@ -352,6 +441,6 @@ def test_withdraw_event(
         sender,
         receiver,
         open_block_number,
-        withdraw_balance)
+        balance)
     )
     ev_handler.check()

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -164,3 +164,4 @@ def test_get_channel_info(web3, get_accounts, uraiden_instance, token_instance, 
     assert channel_data[1] == 100
     assert channel_data[2] == 0
     assert channel_data[3] == 0
+    assert channel_data[4] == 0


### PR DESCRIPTION
closes https://github.com/raiden-network/microraiden/issues/248

- add `withdraw` function 
  - estimated gas cost: `72525` first withdrawal, `42589` subsequent withdrawals
- add `ChannelWithdraw` event
- `getChannelInfo` now returns
```
return (
            key,
            channels[key].deposit,
            closing_requests[key].settle_block_number,
            closing_requests[key].closing_balance,
            withdrawn_balances[key]
        );
```
- added `_receiver_tokens` to `ChannelSettled`
```
event ChannelSettled(
        address indexed _sender,
        address indexed _receiver,
        uint32 indexed _open_block_number,
        uint192 _balance,
        uint192 _receiver_tokens);
```
- tests
  
  