### PR TITLE
Update ethereum-tester to eth-tester==0.1.0b5

### DIFF
--- a/microraiden/requirements-dev.txt
+++ b/microraiden/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 pytest>=2.7.2,!=3.3.*
-ethereum-tester
+eth-tester==0.1.0b5
 mock
 requests_mock

--- a/microraiden/requirements.txt
+++ b/microraiden/requirements.txt
@@ -2,7 +2,6 @@ cytoolz==0.8.2
 eth-utils>=0.7.4
 eth-keyfile==0.4.0
 eth-keys==0.1.0-beta.3
-eth-tester==0.1.0b5
 coincurve
 rlp>=0.4.3,<0.6.0
 flask


### PR DESCRIPTION
fixes https://github.com/raiden-network/microraiden/issues/303

This was solved for `requirements.txt`, but not for `requirements-dev.txt` in  https://github.com/raiden-network/microraiden/pull/327

Version is strictly specified due to version dependency issues related to the `cytoolz` package.

  