### PR TITLE
Update config.py

### DIFF
--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -21,7 +21,7 @@ NETWORK_NAMES = {
 
 # address of the default channel manager contract. You can change this using commandline
 # option --channel-manager-address when running the proxy
-CHANNEL_MANAGER_ADDRESS = '0x161a0d7726eb8b86eb587d8bd483be1ce87b0609'  # ropsten
+CHANNEL_MANAGER_ADDRESS = '0x161a0d7726EB8B86EB587d8BD483be1CE87b0609'   # ropsten
 # absolute path to this directory. Used to find path to the webUI sources
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # webUI sources


### PR DESCRIPTION
I have updated the channel manager address, as it currently causes this error in the echo_server.py example.
```
File "/root/micro-raiden/micro-raiden/env/lib/python3.5/site-packages/web3/utils/validation.py", line 117, in validate_address
    raise InvalidAddress("Address has an invalid EIP checksum", value)
web3.exceptions.InvalidAddress: ('Address has an invalid EIP checksum', '0x161a0d7726eb8b86eb587d8bd483be1ce87b0609')
```

got address from https://ropsten.etherscan.io/address/0x161a0d7726eb8b86eb587d8bd483be1ce87b0609