### PR TITLE
Tests can be run on Ropsten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /env
 /.idea
+credentials/
 *.egg-info
 __pycache__

--- a/microraiden/microraiden/channel_manager/blockchain.py
+++ b/microraiden/microraiden/channel_manager/blockchain.py
@@ -7,7 +7,7 @@ from ethereum.exceptions import InsufficientBalance
 from web3 import Web3
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput
-from eth_utils import is_same_address
+from eth_utils import is_same_address, to_checksum_address
 
 import microraiden.config as config
 from microraiden.utils import get_logs
@@ -141,6 +141,7 @@ class Blockchain(gevent.Greenlet):
         for log in logs:
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             deposit = log['args']['_deposit']
             open_block_number = log['blockNumber']
             self.log.debug(
@@ -159,6 +160,7 @@ class Blockchain(gevent.Greenlet):
         for log in logs:
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             deposit = log['args']['_deposit']
             open_block_number = log['blockNumber']
             self.log.debug('received ChannelOpened event (sender %s, block number %s)',
@@ -175,6 +177,7 @@ class Blockchain(gevent.Greenlet):
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             txhash = log['transactionHash']
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             open_block_number = log['args']['_open_block_number']
             added_deposit = log['args']['_added_deposit']
             self.log.debug(
@@ -200,6 +203,7 @@ class Blockchain(gevent.Greenlet):
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             txhash = log['transactionHash']
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             open_block_number = log['args']['_open_block_number']
             added_deposit = log['args']['_added_deposit']
             self.log.debug(
@@ -219,6 +223,7 @@ class Blockchain(gevent.Greenlet):
         for log in logs:
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             open_block_number = log['args']['_open_block_number']
             self.log.debug('received ChannelSettled event (sender %s, block number %s)',
                            sender, open_block_number)
@@ -233,6 +238,7 @@ class Blockchain(gevent.Greenlet):
         for log in logs:
             assert is_same_address(log['args']['_receiver_address'], self.cm.state.receiver)
             sender = log['args']['_sender_address']
+            sender = to_checksum_address(sender)
             open_block_number = log['args']['_open_block_number']
             if (sender, open_block_number) not in self.cm.channels:
                 continue

--- a/microraiden/microraiden/channel_manager/manager.py
+++ b/microraiden/microraiden/channel_manager/manager.py
@@ -7,7 +7,8 @@ import logging
 import os
 from eth_utils import (
     decode_hex,
-    is_same_address
+    is_same_address,
+    is_checksum_address
 )
 from ethereum.exceptions import InsufficientBalance
 from web3 import Web3
@@ -126,6 +127,7 @@ class ChannelManager(gevent.Greenlet):
 
     def event_channel_opened(self, sender, open_block_number, deposit):
         """Notify the channel manager of a new confirmed channel opening."""
+        assert is_checksum_address(sender)
         if (sender, open_block_number) in self.channels:
             return  # ignore event if already provessed
         c = Channel(self.state.receiver, sender, deposit, open_block_number)
@@ -136,6 +138,7 @@ class ChannelManager(gevent.Greenlet):
 
     def unconfirmed_event_channel_opened(self, sender, open_block_number, deposit):
         """Notify the channel manager of a new channel opening that has not been confirmed yet."""
+        assert is_checksum_address(sender)
         event_already_processed = (sender, open_block_number) in self.unconfirmed_channels
         channel_already_confirmed = (sender, open_block_number) in self.channels
         if event_already_processed or channel_already_confirmed:
@@ -148,8 +151,9 @@ class ChannelManager(gevent.Greenlet):
                       sender, open_block_number)
 
     def event_channel_close_requested(self, sender, open_block_number, balance, settle_timeout):
-        assert settle_timeout >= 0
         """Notify the channel manager that a the closing of a channel has been requested."""
+        assert is_checksum_address(sender)
+        assert settle_timeout >= 0
         if (sender, open_block_number) not in self.channels:
             self.log.warning(
                 'attempt to close a non existing channel (sender %ss, block_number %ss)',
@@ -175,6 +179,7 @@ class ChannelManager(gevent.Greenlet):
 
     def event_channel_settled(self, sender, open_block_number):
         """Notify the channel manager that a channel has been settled."""
+        assert is_checksum_address(sender)
         self.log.info('Forgetting settled channel (sender %s, block number %s)',
                       sender, open_block_number)
         self.state.del_channel(sender, open_block_number)
@@ -183,6 +188,7 @@ class ChannelManager(gevent.Greenlet):
             self, sender, open_block_number, txhash, added_deposit
     ):
         """Notify the channel manager of a topup with not enough confirmations yet."""
+        assert is_checksum_address(sender)
         if (sender, open_block_number) not in self.channels:
             assert (sender, open_block_number) in self.unconfirmed_channels
             self.log.info('Ignoring unconfirmed topup of unconfirmed channel '
@@ -198,6 +204,7 @@ class ChannelManager(gevent.Greenlet):
 
     def event_channel_topup(self, sender, open_block_number, txhash, added_deposit):
         """Notify the channel manager that the deposit of a channel has been topped up."""
+        assert is_checksum_address(sender)
         self.log.info(
             'Registering deposit top up (sender %s, block number %s, added deposit %s)',
             sender, open_block_number, added_deposit
@@ -219,6 +226,7 @@ class ChannelManager(gevent.Greenlet):
 
     def close_channel(self, sender, open_block_number):
         """Close and settle a channel."""
+        assert is_checksum_address(sender)
         if not (sender, open_block_number) in self.channels:
             self.log.warning(
                 "attempt to close a non-registered channel (sender=%s open_block=%s" %
@@ -266,6 +274,7 @@ class ChannelManager(gevent.Greenlet):
 
     def force_close_channel(self, sender, open_block_number):
         """Forcibly remove a channel from our channel state"""
+        assert is_checksum_address(sender)
         try:
             self.close_channel(sender, open_block_number)
             return
@@ -276,6 +285,7 @@ class ChannelManager(gevent.Greenlet):
 
     def sign_close(self, sender, open_block_number, balance):
         """Sign an agreement for a channel closing."""
+        assert is_checksum_address(sender)
         if (sender, open_block_number) not in self.channels:
             raise NoOpenChannel('Channel does not exist or has been closed'
                                 '(sender=%s, open_block_number=%d)' % (sender, open_block_number))
@@ -321,6 +331,7 @@ class ChannelManager(gevent.Greenlet):
 
         :returns: the channel
         """
+        assert is_checksum_address(sender)
         if (sender, open_block_number) in self.unconfirmed_channels:
             raise InsufficientConfirmations(
                 'Insufficient confirmations for the channel '
@@ -348,6 +359,7 @@ class ChannelManager(gevent.Greenlet):
 
     def register_payment(self, sender, open_block_number, balance, signature):
         """Register a payment."""
+        assert is_checksum_address(sender)
         c = self.verify_balance_proof(sender, open_block_number, balance, signature)
         if balance <= c.balance:
             raise InvalidBalanceAmount('The balance must not decrease.')

--- a/microraiden/microraiden/click_helpers.py
+++ b/microraiden/microraiden/click_helpers.py
@@ -91,9 +91,6 @@ def main(
         sys.exit(1)
 
     receiver_address = privkey_to_addr(private_key)
-    channel_manager_address = to_checksum_address(
-        channel_manager_address or config.CHANNEL_MANAGER_ADDRESS
-    )
 
     if not state_file:
         state_file_name = "%s_%s.db" % (channel_manager_address[:10], receiver_address[:10])
@@ -106,6 +103,9 @@ def main(
     while True:
         try:
             web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
+            channel_manager_address = to_checksum_address(
+                channel_manager_address or config.CHANNEL_MANAGER_ADDRESS[web3.version.network]
+            )
             app = make_paywalled_proxy(private_key, state_file,
                                        contract_address=channel_manager_address,
                                        web3=web3)

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -25,7 +25,7 @@ class Client:
             self,
             private_key: str = None,
             key_password_path: str = None,
-            channel_manager_address: str = CHANNEL_MANAGER_ADDRESS,
+            channel_manager_address: str = None,
             web3: Web3 = None
     ) -> None:
         is_hex_key = is_hex(private_key) and len(remove_0x_prefix(private_key)) == 64
@@ -43,6 +43,10 @@ class Client:
         # a new one.
         if not web3:
             web3 = Web3(HTTPProvider('http://localhost:8545'))
+
+        channel_manager_address = (
+            channel_manager_address or CHANNEL_MANAGER_ADDRESS[web3.version.network]
+        )
 
         self.context = Context(private_key, web3, channel_manager_address)
 

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -13,7 +13,7 @@ from microraiden.utils import (
     create_signed_contract_transaction
 )
 
-from microraiden.config import CHANNEL_MANAGER_ADDRESS
+from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
 from microraiden.client.context import Context
 from microraiden.client.channel import Channel
 
@@ -42,7 +42,7 @@ class Client:
         # Create web3 context if none is provided, either by using the proxies' context or creating
         # a new one.
         if not web3:
-            web3 = Web3(HTTPProvider('http://localhost:8545'))
+            web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
 
         channel_manager_address = (
             channel_manager_address or CHANNEL_MANAGER_ADDRESS[web3.version.network]

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -181,6 +181,8 @@ class Client:
 
         if event:
             log.debug('Event received. Channel created in block {}.'.format(event['blockNumber']))
+            assert is_same_address(event['args']['_sender_address'], self.context.address)
+            assert is_same_address(event['args']['_receiver_address'], receiver_address)
             channel = Channel(
                 self.context,
                 self.context.address,

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -42,7 +42,7 @@ class Client:
         # Create web3 context if none is provided, either by using the proxies' context or creating
         # a new one.
         if not web3:
-            web3 = Web3(HTTPProvider())
+            web3 = Web3(HTTPProvider('http://localhost:8545'))
 
         self.context = Context(private_key, web3, channel_manager_address)
 
@@ -101,7 +101,7 @@ class Client:
                     e['args']['_deposit'],
                     on_settle=lambda channel: self.channels.remove(channel)
                 )
-                assert c.sender == self.context.address
+                assert is_same_address(c.sender, self.context.address)
                 channel_key_to_channel[(c.sender, c.receiver, c.block)] = c
 
         for e in topup:
@@ -171,6 +171,7 @@ class Client:
             self.context.channel_manager,
             'ChannelCreated',
             from_block=current_block + 1,
+            to_block='latest',
             argument_filters=filters
         )
 

--- a/microraiden/microraiden/client/session.py
+++ b/microraiden/microraiden/client/session.py
@@ -38,7 +38,7 @@ class Session(requests.Session):
             self.client = Client(**client_kwargs)
 
     def close(self):
-        if self.close_channel_on_exit:
+        if self.close_channel_on_exit and self.channel.state == Channel.State.open:
             self.close_channel()
         requests.Session.close(self)
 

--- a/microraiden/microraiden/close_all_channels.py
+++ b/microraiden/microraiden/close_all_channels.py
@@ -67,7 +67,6 @@ def main(
         sys.exit(1)
 
     receiver_address = privkey_to_addr(private_key)
-    channel_manager_address = channel_manager_address or config.CHANNEL_MANAGER_ADDRESS
 
     if not state_file:
         state_file_name = "%s_%s.json" % (channel_manager_address[:10], receiver_address[:10])
@@ -76,7 +75,10 @@ def main(
 
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
     web3.eth.defaultAccount = receiver_address
-    channel_manager_contract = make_channel_manager_contract(web3, config.CHANNEL_MANAGER_ADDRESS)
+    channel_manager_address = (
+        channel_manager_address or config.CHANNEL_MANAGER_ADDRESS[web3.version.network]
+    )
+    channel_manager_contract = make_channel_manager_contract(web3, channel_manager_address)
 
     try:
         click.echo('Loading state file from {}'.format(state_file))

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -21,7 +21,11 @@ NETWORK_NAMES = {
 
 # address of the default channel manager contract. You can change this using commandline
 # option --channel-manager-address when running the proxy
-CHANNEL_MANAGER_ADDRESS = '0x161a0d7726eb8b86eb587d8bd483be1ce87b0609'  # ropsten
+CHANNEL_MANAGER_ADDRESS = {
+    '1': '',
+    '3': '0x161a0d7726EB8B86EB587d8BD483be1CE87b0609',
+    '42': '0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400'
+}
 # absolute path to this directory. Used to find path to the webUI sources
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # webUI sources

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -4,6 +4,9 @@ from eth_utils import denoms
 
 API_PATH = "/api/1"
 GAS_LIMIT = 130000
+
+# Plain old transaction, for lack of a better term.
+POT_GAS_LIMIT = 21000
 GAS_PRICE = 50 * denoms.gwei
 
 NETWORK_NAMES = {

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -7,7 +7,7 @@ GAS_LIMIT = 130000
 
 # Plain old transaction, for lack of a better term.
 POT_GAS_LIMIT = 21000
-GAS_PRICE = 50 * denoms.gwei
+GAS_PRICE = 20 * denoms.gwei
 
 NETWORK_NAMES = {
     1: 'mainnet',

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -3,8 +3,8 @@ import os
 from eth_utils import denoms
 
 API_PATH = "/api/1"
-GAS_LIMIT = 250000
-GAS_PRICE = 20 * denoms.gwei
+GAS_LIMIT = 130000
+GAS_PRICE = 50 * denoms.gwei
 
 NETWORK_NAMES = {
     1: 'mainnet',

--- a/microraiden/microraiden/examples/echo_client.py
+++ b/microraiden/microraiden/examples/echo_client.py
@@ -10,8 +10,6 @@ from microraiden import Session
 import logging
 import requests
 
-from microraiden.config import CHANNEL_MANAGER_ADDRESS
-
 
 @click.command()
 @click.option(
@@ -39,7 +37,7 @@ def run(
         key_path: str,
         key_password_path: str,
         resource: str,
-        channel_manager_address: str = CHANNEL_MANAGER_ADDRESS,
+        channel_manager_address: str = None,
         web3: Web3 = None,
         retry_interval: float = 5,
         endpoint_url: str = 'http://localhost:5000'

--- a/microraiden/microraiden/examples/echo_client.py
+++ b/microraiden/microraiden/examples/echo_client.py
@@ -13,29 +13,29 @@ import requests
 
 @click.command()
 @click.option(
-    '--key-path',
+    '--private-key',
     required=True,
-    help='Path to private key file.',
+    help='Path to private key file or a hex-encoded private key.',
     type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )
 @click.option(
-    '--key-password-path',
+    '--password-path',
     default=None,
-    help='Path to file containing password for private key.',
+    help='Path to file containing the password for the private key specified.',
     type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )
 @click.option('--resource', required=True, help='Get this resource.')
 def main(
-        key_path: str,
-        key_password_path: str,
+        private_key: str,
+        password_path: str,
         resource: str
 ):
-    run(key_path, key_password_path, resource)
+    run(private_key, password_path, resource)
 
 
 def run(
-        key_path: str,
-        key_password_path: str,
+        private_key: str,
+        password_path: str,
         resource: str,
         channel_manager_address: str = None,
         web3: Web3 = None,
@@ -45,8 +45,8 @@ def run(
     # Create the client session.
     session = Session(
         endpoint_url=endpoint_url,
-        private_key=key_path,
-        key_password_path=key_password_path,
+        private_key=private_key,
+        key_password_path=password_path,
         channel_manager_address=channel_manager_address,
         web3=web3,
         retry_interval=retry_interval

--- a/microraiden/microraiden/examples/echo_server.py
+++ b/microraiden/microraiden/examples/echo_server.py
@@ -10,7 +10,7 @@ from web3 import Web3, HTTPProvider
 
 from microraiden.channel_manager import ChannelManager
 from microraiden.make_helpers import make_channel_manager
-from microraiden.config import CHANNEL_MANAGER_ADDRESS
+from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
 from microraiden.proxy import PaywalledProxy
 from microraiden.proxy.resources import Expensive
 from microraiden.utils import get_private_key
@@ -61,7 +61,7 @@ def run(
     #  - private key to use for receiving funds
     #  - file for storing state information (balance proofs)
     if channel_manager is None:
-        web3 = Web3(HTTPProvider('http://localhost:8545'))
+        web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
         channel_manager = make_channel_manager(
             private_key,
             CHANNEL_MANAGER_ADDRESS[web3.version.network],

--- a/microraiden/microraiden/examples/echo_server.py
+++ b/microraiden/microraiden/examples/echo_server.py
@@ -61,11 +61,12 @@ def run(
     #  - private key to use for receiving funds
     #  - file for storing state information (balance proofs)
     if channel_manager is None:
+        web3 = Web3(HTTPProvider('http://localhost:8545'))
         channel_manager = make_channel_manager(
             private_key,
-            CHANNEL_MANAGER_ADDRESS,
+            CHANNEL_MANAGER_ADDRESS[web3.version.network],
             state_file_path,
-            Web3(HTTPProvider('http://localhost:8545'))
+            web3
         )
     app = PaywalledProxy(channel_manager)
 

--- a/microraiden/microraiden/examples/echo_server.py
+++ b/microraiden/microraiden/examples/echo_server.py
@@ -65,7 +65,7 @@ def run(
             private_key,
             CHANNEL_MANAGER_ADDRESS,
             state_file_path,
-            Web3(HTTPProvider())
+            Web3(HTTPProvider('http://localhost:8545'))
         )
     app = PaywalledProxy(channel_manager)
 

--- a/microraiden/microraiden/examples/eth_ticker.py
+++ b/microraiden/microraiden/examples/eth_ticker.py
@@ -7,8 +7,6 @@ import click
 import os
 
 from microraiden import Session
-from microraiden.utils import privkey_to_addr
-from microraiden.config import CHANNEL_MANAGER_ADDRESS
 from microraiden.proxy import PaywalledProxy
 from microraiden.proxy.resources import PaywalledProxyUrl
 from microraiden.make_helpers import make_paywalled_proxy
@@ -17,9 +15,7 @@ log = logging.getLogger(__name__)
 
 
 def start_proxy(receiver_privkey: str) -> PaywalledProxy:
-    state_file_name = 'ticker_proxy.db'.format(
-        CHANNEL_MANAGER_ADDRESS, privkey_to_addr(receiver_privkey)
-    )
+    state_file_name = 'ticker_proxy.db'
     app_dir = click.get_app_dir('microraiden')
     if not os.path.exists(app_dir):
         os.makedirs(app_dir)

--- a/microraiden/microraiden/examples/eth_ticker.py
+++ b/microraiden/microraiden/examples/eth_ticker.py
@@ -8,7 +8,7 @@ import os
 
 from microraiden import Session
 from microraiden.utils import privkey_to_addr
-from microraiden.config import CHANNEL_MANAGER_ADDRESS, TKN_DECIMALS
+from microraiden.config import CHANNEL_MANAGER_ADDRESS
 from microraiden.proxy import PaywalledProxy
 from microraiden.proxy.resources import PaywalledProxyUrl
 from microraiden.make_helpers import make_paywalled_proxy
@@ -41,7 +41,7 @@ class ETHTickerProxy:
         self.app.add_paywalled_resource(
             PaywalledProxyUrl,
             '/<string:ticker>',
-            1 * TKN_DECIMALS,
+            100,
             **cfg
         )
 

--- a/microraiden/microraiden/make_helpers.py
+++ b/microraiden/microraiden/make_helpers.py
@@ -62,12 +62,13 @@ def make_channel_manager(
 def make_paywalled_proxy(
         private_key: str,
         state_filename: str,
-        contract_address=config.CHANNEL_MANAGER_ADDRESS,
+        contract_address=None,
         flask_app=None,
         web3=None
 ) -> PaywalledProxy:
     if web3 is None:
         web3 = Web3(HTTPProvider(config.WEB3_PROVIDER_DEFAULT, request_kwargs={'timeout': 60}))
+        contract_address = contract_address or config.CHANNEL_MANAGER_ADDRESS[web3.version.network]
     channel_manager = make_channel_manager(private_key, contract_address, state_filename, web3)
     proxy = PaywalledProxy(channel_manager, flask_app, config.HTML_DIR, config.JSLIB_DIR)
     return proxy

--- a/microraiden/microraiden/test/config.py
+++ b/microraiden/microraiden/test/config.py
@@ -8,9 +8,9 @@ MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..
 HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
 JSLIB_DIR = os.path.join(HTML_DIR, 'js')
 
-FAUCET_ALLOWANCE = int(0.123 * denoms.ether)
+FAUCET_ALLOWANCE = 10 * denoms.ether
 INITIAL_TOKEN_SUPPLY = 10**25
-SENDER_ETH_ALLOWANCE = int(0.02 * denoms.ether)
+SENDER_ETH_ALLOWANCE = int(0.5 * denoms.ether)
 SENDER_TOKEN_ALLOWANCE = 10**14
-RECEIVER_ETH_ALLOWANCE = int(0.02 * denoms.ether)
+RECEIVER_ETH_ALLOWANCE = int(0.5 * denoms.ether)
 RECEIVER_TOKEN_ALLOWANCE = 0

--- a/microraiden/microraiden/test/config.py
+++ b/microraiden/microraiden/test/config.py
@@ -1,7 +1,6 @@
 import os
 from eth_utils import denoms
 
-CHANNEL_MANAGER_ADDRESS = '0x161a0d7726EB8B86EB587d8BD483be1CE87b0609'
 API_PATH = "/api/1"
 
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))

--- a/microraiden/microraiden/test/config.py
+++ b/microraiden/microraiden/test/config.py
@@ -1,6 +1,5 @@
 import os
 from eth_utils import denoms
-from microraiden.utils import privkey_to_addr
 
 CHANNEL_MANAGER_ADDRESS = '0xeb244b0502a2d3867e5cab2347c6e1cdeb5e1eef'
 API_PATH = "/api/1"
@@ -9,11 +8,9 @@ MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..
 HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
 JSLIB_DIR = os.path.join(HTML_DIR, 'js')
 
-FAUCET_PRIVKEY = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-FAUCET_ADDRESS = privkey_to_addr(FAUCET_PRIVKEY)
-FAUCET_ALLOWANCE = 10**23
+FAUCET_ALLOWANCE = int(0.5 * denoms.ether)
 INITIAL_TOKEN_SUPPLY = 10**25
 SENDER_ETH_ALLOWANCE = int(0.02 * denoms.ether)
-SENDER_TOKEN_ALLOWANCE = 10**20
+SENDER_TOKEN_ALLOWANCE = 10**14
 RECEIVER_ETH_ALLOWANCE = int(0.02 * denoms.ether)
 RECEIVER_TOKEN_ALLOWANCE = 0

--- a/microraiden/microraiden/test/config.py
+++ b/microraiden/microraiden/test/config.py
@@ -1,14 +1,14 @@
 import os
 from eth_utils import denoms
 
-CHANNEL_MANAGER_ADDRESS = '0xeb244b0502a2d3867e5cab2347c6e1cdeb5e1eef'
+CHANNEL_MANAGER_ADDRESS = '0x161a0d7726EB8B86EB587d8BD483be1CE87b0609'
 API_PATH = "/api/1"
 
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
 JSLIB_DIR = os.path.join(HTML_DIR, 'js')
 
-FAUCET_ALLOWANCE = int(0.5 * denoms.ether)
+FAUCET_ALLOWANCE = int(0.123 * denoms.ether)
 INITIAL_TOKEN_SUPPLY = 10**25
 SENDER_ETH_ALLOWANCE = int(0.02 * denoms.ether)
 SENDER_TOKEN_ALLOWANCE = 10**14

--- a/microraiden/microraiden/test/conftest.py
+++ b/microraiden/microraiden/test/conftest.py
@@ -29,3 +29,15 @@ def pytest_addoption(parser):
         help="the private key to an address with sufficient ETH and RDN tokens to run tests on a "
              "real network, specified either as a file path or a hex-encoded private key"
     )
+    parser.addoption(
+        "--faucet-password-path",
+        default='',
+        dest='faucet_password_path',
+        help="the path to a file containing the password to the faucet's encrypted private key"
+    )
+    parser.addoption(
+        "--private-key-seed",
+        default=14789632,
+        dest='private_key_seed',
+        help="the seed for private key generation for addresses used in tests"
+    )

--- a/microraiden/microraiden/test/conftest.py
+++ b/microraiden/microraiden/test/conftest.py
@@ -22,3 +22,10 @@ def pytest_addoption(parser):
         dest='clean_channels',
         help="prevent all channels from closing cooperatively before and after each test"
     )
+    parser.addoption(
+        "--faucet-private-key",
+        default='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        dest='faucet_private_key',
+        help="the private key to an address with sufficient ETH and RDN tokens to run tests on a "
+             "real network, specified either as a file path or a hex-encoded private key"
+    )

--- a/microraiden/microraiden/test/fixtures/accounts.py
+++ b/microraiden/microraiden/test/fixtures/accounts.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 import pytest
@@ -26,6 +27,9 @@ from microraiden.test.config import (
     SENDER_ETH_ALLOWANCE,
     SENDER_TOKEN_ALLOWANCE
 )
+
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='session')
@@ -108,6 +112,7 @@ def fund_account(
         wait_for_transaction,
         faucet_private_key: str,
 ):
+    log.info('Funding account {}'.format(address))
     tx = create_signed_transaction(
         faucet_private_key,
         web3,
@@ -140,6 +145,7 @@ def sweep_account(
         wait_for_transaction
 ):
     address = privkey_to_addr(private_key)
+    log.info('Sweeping account {}'.format(address))
     token_balance = token_contract.call().balanceOf(address)
     if token_balance > 0:
         tx = create_signed_contract_transaction(

--- a/microraiden/microraiden/test/fixtures/accounts.py
+++ b/microraiden/microraiden/test/fixtures/accounts.py
@@ -20,7 +20,7 @@ from microraiden.utils import (
     create_signed_transaction,
     get_private_key
 )
-from microraiden.config import GAS_PRICE
+from microraiden.config import GAS_PRICE, POT_GAS_LIMIT
 from microraiden.test.config import (
     RECEIVER_ETH_ALLOWANCE,
     RECEIVER_TOKEN_ALLOWANCE,
@@ -117,8 +117,7 @@ def fund_account(
         faucet_private_key,
         web3,
         to=address,
-        value=eth_allowance,
-        gas_limit=21000
+        value=eth_allowance
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)
@@ -169,14 +168,14 @@ def sweep_account(
             assert token_contract.call().balanceOf(address) == 0
 
     balance = web3.eth.getBalance(address)
-    if balance < 21000 * GAS_PRICE:
+    if balance < POT_GAS_LIMIT * GAS_PRICE:
         return
     tx = create_signed_transaction(
         private_key,
         web3,
         to=faucet_address,
-        value=balance - 21000 * GAS_PRICE,
-        gas_limit=21000
+        value=balance - POT_GAS_LIMIT * GAS_PRICE,
+        gas_limit=POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)

--- a/microraiden/microraiden/test/fixtures/accounts.py
+++ b/microraiden/microraiden/test/fixtures/accounts.py
@@ -6,6 +6,8 @@ from eth_utils import (
     encode_hex,
     int_to_big_endian,
     pad_left,
+    is_hex,
+    remove_0x_prefix
 )
 import ethereum.tester
 from web3 import Web3
@@ -14,16 +16,15 @@ from web3.contract import Contract
 from microraiden.utils import (
     privkey_to_addr,
     create_signed_contract_transaction,
-    create_signed_transaction
+    create_signed_transaction,
+    get_private_key
 )
 from microraiden.config import GAS_PRICE
 from microraiden.test.config import (
     RECEIVER_ETH_ALLOWANCE,
     RECEIVER_TOKEN_ALLOWANCE,
     SENDER_ETH_ALLOWANCE,
-    SENDER_TOKEN_ALLOWANCE,
-    FAUCET_PRIVKEY,
-    FAUCET_ADDRESS,
+    SENDER_TOKEN_ALLOWANCE
 )
 
 
@@ -35,12 +36,31 @@ def random_private_key(bound):
 
 
 @pytest.fixture(scope='session')
+def faucet_private_key(request) -> str:
+    private_key = request.config.getoption('faucet_private_key')
+    if is_hex(private_key):
+        assert len(remove_0x_prefix(private_key)) == 64
+        return private_key
+    else:
+        private_key = get_private_key(private_key)
+        assert private_key is not None, 'Error loading faucet private key from file.'
+        return private_key
+
+
+@pytest.fixture(scope='session')
+def faucet_address(faucet_private_key: str):
+    return privkey_to_addr(faucet_private_key)
+
+
+@pytest.fixture(scope='session')
 def make_account(
         request,
         web3: Web3,
         wait_for_transaction,
         use_tester: bool,
-        token_contract: Contract
+        token_contract: Contract,
+        faucet_private_key: str,
+        faucet_address: str
 ):
     def account_factory(eth_allowance, token_allowance):
         privkey = random_private_key(1000)
@@ -54,11 +74,12 @@ def make_account(
             token_allowance,
             token_contract,
             web3,
-            wait_for_transaction
+            wait_for_transaction,
+            faucet_private_key
         )
 
         def finalize():
-            sweep_account(privkey, token_contract, web3, wait_for_transaction)
+            sweep_account(privkey, faucet_address, token_contract, web3, wait_for_transaction)
             if use_tester:
                 ethereum.tester.accounts.remove(decode_hex(address))
                 ethereum.tester.keys.remove(decode_hex(privkey))
@@ -73,10 +94,11 @@ def fund_account(
         token_allowance: int,
         token_contract: Contract,
         web3: Web3,
-        wait_for_transaction
+        wait_for_transaction,
+        faucet_private_key: str,
 ):
     tx = create_signed_transaction(
-        FAUCET_PRIVKEY,
+        faucet_private_key,
         web3,
         to=address,
         value=eth_allowance,
@@ -87,7 +109,7 @@ def fund_account(
 
     if token_allowance > 0:
         tx = create_signed_contract_transaction(
-            FAUCET_PRIVKEY,
+            faucet_private_key,
             token_contract,
             'transfer',
             [
@@ -99,7 +121,13 @@ def fund_account(
         wait_for_transaction(tx_hash)
 
 
-def sweep_account(private_key: str, token_contract: Contract, web3: Web3, wait_for_transaction):
+def sweep_account(
+        private_key: str,
+        faucet_address: str,
+        token_contract: Contract,
+        web3: Web3,
+        wait_for_transaction
+):
     address = privkey_to_addr(private_key)
     token_balance = token_contract.call().balanceOf(address)
     if token_balance > 0:
@@ -108,7 +136,7 @@ def sweep_account(private_key: str, token_contract: Contract, web3: Web3, wait_f
             token_contract,
             'transfer',
             [
-                FAUCET_ADDRESS,
+                faucet_address,
                 token_balance
             ]
         )
@@ -128,7 +156,7 @@ def sweep_account(private_key: str, token_contract: Contract, web3: Web3, wait_f
     tx = create_signed_transaction(
         private_key,
         web3,
-        to=FAUCET_ADDRESS,
+        to=faucet_address,
         value=balance - 21000 * GAS_PRICE,
         gas_limit=21000
     )
@@ -139,21 +167,21 @@ def sweep_account(private_key: str, token_contract: Contract, web3: Web3, wait_f
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def sender_privkey(make_account):
     return make_account(SENDER_ETH_ALLOWANCE, SENDER_TOKEN_ALLOWANCE)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def sender_address(sender_privkey):
     return privkey_to_addr(sender_privkey)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def receiver_privkey(make_account):
     return make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def receiver_address(receiver_privkey):
     return privkey_to_addr(receiver_privkey)

--- a/microraiden/microraiden/test/fixtures/client.py
+++ b/microraiden/microraiden/test/fixtures/client.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 from web3 import Web3
 
@@ -32,7 +34,7 @@ def client(
         channel_manager_address: str,
         web3: Web3,
         clean_channels: bool,
-        receiver_privkey: str,
+        private_keys: List[str],
         patched_contract,
         revert_chain
 ):
@@ -44,7 +46,7 @@ def client(
     if clean_channels:
         close_all_channels_cooperatively(
             client,
-            receiver_privkey,
+            private_keys,
             channel_manager_address,
             balance=0
         )
@@ -54,7 +56,7 @@ def client(
     if clean_channels:
         close_all_channels_cooperatively(
             client,
-            receiver_privkey,
+            private_keys,
             channel_manager_address,
             balance=0
         )

--- a/microraiden/microraiden/test/fixtures/session.py
+++ b/microraiden/microraiden/test/fixtures/session.py
@@ -15,10 +15,14 @@ def session(client: Client, use_tester: bool, api_endpoint_address: str):
             self.client.context.web3.testing.mine(1)
         return Session._request_resource(self, method, url, **kwargs)
 
+    kwargs = {}
+    if use_tester:
+        kwargs['retry_interval'] = 0.1
+
     session = Session(
         client,
-        retry_interval=0.1,
-        endpoint_url='http://' + api_endpoint_address
+        endpoint_url='http://' + api_endpoint_address,
+        **kwargs
     )
     session._request_resource = types.MethodType(request_patched, session)
     yield session

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -244,6 +244,8 @@ def revert_chain(web3: Web3, use_tester: bool, sender_privkey: str, receiver_pri
         snapshot_id = web3.testing.snapshot()
         yield
         web3.testing.revert(snapshot_id)
+    else:
+        yield
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -14,7 +14,7 @@ from web3 import Web3, EthereumTesterProvider
 from web3.contract import Contract
 from web3.providers.rpc import HTTPProvider
 
-from microraiden.config import CHANNEL_MANAGER_ADDRESS
+from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
 from microraiden.utils import (
     addr_from_sig,
     keccak256,
@@ -168,7 +168,7 @@ def web3(use_tester: bool, faucet_private_key: str, faucet_address: str, mine_sy
         web3.eth.sendTransaction({'to': faucet_address, 'value': FAUCET_ALLOWANCE})
 
     else:
-        rpc = HTTPProvider('http://localhost:8545')
+        rpc = HTTPProvider(WEB3_PROVIDER_DEFAULT)
         web3 = Web3(rpc)
 
     yield web3

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -14,12 +14,12 @@ from web3 import Web3, EthereumTesterProvider
 from web3.contract import Contract
 from web3.providers.rpc import HTTPProvider
 
+from microraiden.config import CHANNEL_MANAGER_ADDRESS
 from microraiden.utils import (
     addr_from_sig,
     keccak256,
 )
 from microraiden.test.config import (
-    CHANNEL_MANAGER_ADDRESS,
     FAUCET_ALLOWANCE,
     INITIAL_TOKEN_SUPPLY
 )
@@ -73,7 +73,7 @@ def token_address(
     else:
         channel_manager = web3.eth.contract(
             abi=channel_manager_abi,
-            address=CHANNEL_MANAGER_ADDRESS
+            address=CHANNEL_MANAGER_ADDRESS[web3.version.network]
         )
         return channel_manager.call().token()
 
@@ -112,7 +112,7 @@ def channel_manager_address(
         )
         return contract.address
     else:
-        return CHANNEL_MANAGER_ADDRESS
+        return CHANNEL_MANAGER_ADDRESS[web3.version.network]
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -163,7 +163,7 @@ def web3(use_tester, mine_sync_event):
         web3.eth.sendTransaction({'to': FAUCET_ADDRESS, 'value': FAUCET_ALLOWANCE})
 
     else:
-        rpc = HTTPProvider('localhost', 8545)
+        rpc = HTTPProvider('http://localhost:8545')
         web3 = Web3(rpc)
 
     yield web3

--- a/microraiden/microraiden/test/test_broke_proxy.py
+++ b/microraiden/microraiden/test/test_broke_proxy.py
@@ -1,5 +1,4 @@
 from microraiden import Session
-from microraiden.test.utils.client import patch_on_http_response
 
 from microraiden.test.config import (
     FAUCET_ADDRESS,
@@ -14,7 +13,6 @@ def test_cheating_client(
         wait_for_blocks,
         http_doggo_url: str,
 ):
-    patch_on_http_response(session, abort_on=[502])
     balance = web3.eth.getBalance(doggo_proxy.channel_manager.receiver)
     assert balance > 0
     # remove all receiver's eth
@@ -22,13 +20,13 @@ def test_cheating_client(
                               'to': FAUCET_ADDRESS,
                               'value': balance - 4 * 10**7})
     wait_for_blocks(1)
-    session.get(http_doggo_url)
+    response = session.get(http_doggo_url)
     # proxy is expected to return 502 - it has no funds
-    assert session.last_response.status_code == 502
+    assert response.status_code == 502
     web3.eth.sendTransaction({'from': FAUCET_ADDRESS,
                               'to': doggo_proxy.channel_manager.receiver,
                               'value': balance})
     wait_for_blocks(1)
-    session.get(http_doggo_url)
+    response = session.get(http_doggo_url)
     # now it should proceed normally
-    assert session.last_response.status_code == 200
+    assert response.status_code == 200

--- a/microraiden/microraiden/test/test_broke_proxy.py
+++ b/microraiden/microraiden/test/test_broke_proxy.py
@@ -1,29 +1,25 @@
 from microraiden import Session
 
-from microraiden.test.config import (
-    FAUCET_ADDRESS,
-)
 
-
-#  @pytest.mark.skip(reason="waiting for client to return status code")
 def test_cheating_client(
         doggo_proxy,
         web3,
         session: Session,
         wait_for_blocks,
         http_doggo_url: str,
+        faucet_address: str
 ):
     balance = web3.eth.getBalance(doggo_proxy.channel_manager.receiver)
     assert balance > 0
     # remove all receiver's eth
     web3.eth.sendTransaction({'from': doggo_proxy.channel_manager.receiver,
-                              'to': FAUCET_ADDRESS,
+                              'to': faucet_address,
                               'value': balance - 4 * 10**7})
     wait_for_blocks(1)
     response = session.get(http_doggo_url)
     # proxy is expected to return 502 - it has no funds
     assert response.status_code == 502
-    web3.eth.sendTransaction({'from': FAUCET_ADDRESS,
+    web3.eth.sendTransaction({'from': faucet_address,
                               'to': doggo_proxy.channel_manager.receiver,
                               'value': balance})
     wait_for_blocks(1)

--- a/microraiden/microraiden/test/test_broke_proxy.py
+++ b/microraiden/microraiden/test/test_broke_proxy.py
@@ -1,5 +1,5 @@
 from microraiden import Session
-from microraiden.config import GAS_PRICE
+from microraiden.config import GAS_PRICE, POT_GAS_LIMIT
 from microraiden.utils import create_signed_transaction
 
 
@@ -21,7 +21,7 @@ def test_cheating_client(
         receiver_privkey,
         web3,
         faucet_address,
-        balance - GAS_PRICE * 21000
+        balance - GAS_PRICE * POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)
@@ -32,7 +32,7 @@ def test_cheating_client(
         faucet_private_key,
         web3,
         receiver_address,
-        balance - GAS_PRICE * 21000
+        balance - GAS_PRICE * POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)

--- a/microraiden/microraiden/test/test_channel_manager.py
+++ b/microraiden/microraiden/test/test_channel_manager.py
@@ -1,5 +1,7 @@
 import logging
 from itertools import count
+from typing import List
+
 from eth_utils import is_same_address, encode_hex
 from web3 import Web3
 from web3.contract import Contract
@@ -39,6 +41,7 @@ def test_channel_opening(
         client: Client,
         web3: Web3,
         make_account,
+        private_keys: List[str],
         channel_manager_contract,
         token_contract,
         mine_sync_event,
@@ -46,8 +49,16 @@ def test_channel_opening(
         use_tester,
         state_db_path
 ):
-    receiver1_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
-    receiver2_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
+    receiver1_privkey = make_account(
+        RECEIVER_ETH_ALLOWANCE,
+        RECEIVER_TOKEN_ALLOWANCE,
+        private_keys[2]
+    )
+    receiver2_privkey = make_account(
+        RECEIVER_ETH_ALLOWANCE,
+        RECEIVER_TOKEN_ALLOWANCE,
+        private_keys[3]
+    )
     receiver_address = privkey_to_addr(receiver1_privkey)
     # make sure channel_manager1 is terminated properly, otherwise Blockchain will be running
     #  in the background, ruining other tests' results
@@ -536,6 +547,7 @@ def test_balances(
 def test_different_receivers(
         web3: Web3,
         make_account,
+        private_keys: List[str],
         channel_manager_contract: Contract,
         token_contract: Contract,
         mine_sync_event,
@@ -545,8 +557,16 @@ def test_different_receivers(
         use_tester: bool,
         state_db_path: str
 ):
-    receiver1_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
-    receiver2_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
+    receiver1_privkey = make_account(
+        RECEIVER_ETH_ALLOWANCE,
+        RECEIVER_TOKEN_ALLOWANCE,
+        private_keys[2]
+    )
+    receiver2_privkey = make_account(
+        RECEIVER_ETH_ALLOWANCE,
+        RECEIVER_TOKEN_ALLOWANCE,
+        private_keys[3]
+    )
     receiver1_address = privkey_to_addr(receiver1_privkey)
     channel_manager1 = ChannelManager(
         web3,

--- a/microraiden/microraiden/test/test_channel_manager.py
+++ b/microraiden/microraiden/test/test_channel_manager.py
@@ -142,7 +142,6 @@ def test_close_unconfirmed_event(
 def test_close_confirmed_event(
         channel_manager: ChannelManager,
         confirmed_open_channel: Channel,
-        web3: Web3,
         wait_for_blocks
 ):
     blockchain = channel_manager.blockchain
@@ -168,7 +167,8 @@ def test_channel_settled_event(
         channel_manager: ChannelManager,
         confirmed_open_channel: Channel,
         wait_for_blocks,
-        web3: Web3
+        web3: Web3,
+        use_tester: bool
 ):
     blockchain = channel_manager.blockchain
     channel_manager.wait_sync()

--- a/microraiden/microraiden/test/test_channel_manager.py
+++ b/microraiden/microraiden/test/test_channel_manager.py
@@ -578,6 +578,7 @@ def test_different_receivers(
     channel = client.open_channel(receiver1_address, 10)
     wait_for_blocks(1)
     gevent.sleep(blockchain.poll_interval)
+
     assert (sender_address, channel.block) in channel_manager1.unconfirmed_channels
     assert (sender_address, channel.block) not in channel_manager2.unconfirmed_channels
 

--- a/microraiden/microraiden/test/test_channel_manager.py
+++ b/microraiden/microraiden/test/test_channel_manager.py
@@ -170,6 +170,9 @@ def test_channel_settled_event(
         web3: Web3,
         use_tester: bool
 ):
+    if not use_tester:
+        pytest.skip('This test takes several hours on real blockchains.')
+
     blockchain = channel_manager.blockchain
     channel_manager.wait_sync()
     channel_id = (confirmed_open_channel.sender, confirmed_open_channel.block)
@@ -435,8 +438,12 @@ def test_settlement(
         wait_for_blocks,
         web3: Web3,
         token_contract: Contract,
-        sender_address: str
+        sender_address: str,
+        use_tester: bool
 ):
+    if not use_tester:
+        pytest.skip('This test takes several hours on real blockchains.')
+
     blockchain = channel_manager.blockchain
     channel_id = (confirmed_open_channel.sender, confirmed_open_channel.block)
 
@@ -557,6 +564,9 @@ def test_different_receivers(
         use_tester: bool,
         state_db_path: str
 ):
+    if not use_tester:
+        pytest.skip('This test takes several hours on real blockchains.')
+
     receiver1_privkey = make_account(
         RECEIVER_ETH_ALLOWANCE,
         RECEIVER_TOKEN_ALLOWANCE,

--- a/microraiden/microraiden/test/test_contract.py
+++ b/microraiden/microraiden/test/test_contract.py
@@ -2,7 +2,6 @@ from eth_utils import denoms
 from web3 import Web3
 from web3.utils.empty import empty as web3_empty
 
-from microraiden.test.config import FAUCET_PRIVKEY
 from microraiden.utils import create_signed_transaction, wait_for_transaction
 
 
@@ -53,9 +52,14 @@ def test_create_signed_transaction():
     assert tx == tx_expected
 
 
-def test_wait_for_transaction(web3: Web3, patched_contract, receiver_address: str):
+def test_wait_for_transaction(
+        web3: Web3,
+        patched_contract,
+        receiver_address: str,
+        faucet_private_key: str,
+):
     tx = create_signed_transaction(
-        FAUCET_PRIVKEY,
+        faucet_private_key,
         web3,
         to=receiver_address
     )

--- a/microraiden/microraiden/test/test_crypto.py
+++ b/microraiden/microraiden/test/test_crypto.py
@@ -189,7 +189,7 @@ def test_verify_balance_proof_v0(channel_manager_address: str):
     sig = sign_balance_proof(
         SENDER_PRIVATE_KEY, RECEIVER_ADDR, 312524, 11, channel_manager_address
     )
-    sig = sig[:-1] + b'\x00'
+    sig = sig[:-1] + bytes([sig[-1] % 27])
     assert is_same_address(verify_balance_proof(
         RECEIVER_ADDR, 312524, 11, sig, channel_manager_address
     ), SENDER_ADDR)
@@ -200,7 +200,7 @@ def test_verify_balance_proof_v27(channel_manager_address: str):
     sig = sign_balance_proof(
         SENDER_PRIVATE_KEY, RECEIVER_ADDR, 312524, 11, channel_manager_address
     )
-    sig = sig[:-1] + b'\x1b'
+    sig = sig[:-1] + bytes([sig[-1] % 27 + 27])
     assert is_same_address(verify_balance_proof(
         RECEIVER_ADDR, 312524, 11, sig, channel_manager_address
     ), SENDER_ADDR)

--- a/microraiden/microraiden/test/test_session.py
+++ b/microraiden/microraiden/test/test_session.py
@@ -583,7 +583,7 @@ def test_cooperative_close_denied(
 
     assert response.text == 'success'
     assert cooperative_close_denied_mock.call_count == 1
-    assert session.client.channels[0].state == Channel.State.settling
+    assert session.channel.state == Channel.State.settling
 
 
 def test_error_handling(

--- a/microraiden/microraiden/test/test_session.py
+++ b/microraiden/microraiden/test/test_session.py
@@ -29,7 +29,7 @@ def test_full_cycle_success(
 ):
     session.initial_deposit = lambda x: x
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -49,14 +49,17 @@ def test_full_cycle_success(
         ])
         response = session.get(url)
 
+    # Filter out any requests made to the ethereum node.
+    request_history = [request for request in server_mock.request_history if request.port == 5000]
+
     # First cycle, request price.
-    request = server_mock.request_history[0]
+    request = request_history[0]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
 
     # Second cycle, pay price.
-    request = server_mock.request_history[1]
+    request = request_history[1]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -83,7 +86,7 @@ def test_full_cycle_adapt_balance(
     lost_balance_sig = channel.balance_sig
     channel.update_balance(0)
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -111,14 +114,17 @@ def test_full_cycle_adapt_balance(
 
         response = session.get(url)
 
+    # Filter out any requests made to the ethereum node.
+    request_history = [request for request in server_mock.request_history if request.port == 5000]
+
     # First cycle, request price.
-    request = server_mock.request_history[0]
+    request = request_history[0]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
 
     # Second cycle, pay price based on outdated balance.
-    request = server_mock.request_history[1]
+    request = request_history[1]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -126,7 +132,7 @@ def test_full_cycle_adapt_balance(
     assert request.headers['RDN-Balance-Signature']
 
     # Third cycle, adapt new balance and pay price again.
-    request = server_mock.request_history[2]
+    request = request_history[2]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -148,7 +154,7 @@ def test_full_cycle_error_500(
 ):
     session.initial_deposit = lambda x: x
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -168,14 +174,17 @@ def test_full_cycle_error_500(
         ])
         response = session.get(url)
 
+    # Filter out any requests made to the ethereum node.
+    request_history = [request for request in server_mock.request_history if request.port == 5000]
+
     # First cycle, request price.
-    request = server_mock.request_history[0]
+    request = request_history[0]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
 
     # Second cycle, pay price but receive error.
-    request = server_mock.request_history[1]
+    request = request_history[1]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -196,7 +205,7 @@ def test_full_cycle_success_post(
 ):
     session.initial_deposit = lambda x: x
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -216,15 +225,18 @@ def test_full_cycle_success_post(
         ])
         response = session.post(url, json={'somefield': 'somevalue'})
 
+    # Filter out any requests made to the ethereum node.
+    request_history = [request for request in server_mock.request_history if request.port == 5000]
+
     # First cycle, request price.
-    request = server_mock.request_history[0]
+    request = request_history[0]
     assert request.path == '/something'
     assert request.method == 'POST'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
     assert request.json()['somefield'] == 'somevalue'
 
     # Second cycle, pay price.
-    request = server_mock.request_history[1]
+    request = request_history[1]
     assert request.path == '/something'
     assert request.method == 'POST'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -247,7 +259,7 @@ def test_custom_headers(
 ):
     session.initial_deposit = lambda x: x
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -271,8 +283,11 @@ def test_custom_headers(
             'RDN-Balance': '5'
         })
 
+    # Filter out any requests made to the ethereum node.
+    request_history = [request for request in server_mock.request_history if request.port == 5000]
+
     # First cycle, request price.
-    request = server_mock.request_history[0]
+    request = request_history[0]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -280,7 +295,7 @@ def test_custom_headers(
     assert request.headers['someheader'] == 'somevalue'
 
     # Second cycle, pay price.
-    request = server_mock.request_history[1]
+    request = request_history[1]
     assert request.path == '/something'
     assert request.method == 'GET'
     assert request.headers['RDN-Contract-Address'] == channel_manager_address
@@ -500,7 +515,7 @@ def test_requests(
 ):
     import microraiden.requests
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers1 = Munch()
         headers1.token_address = token_address
         headers1.contract_address = channel_manager_address
@@ -542,7 +557,7 @@ def test_cooperative_close_denied(
         wraps=session.on_cooperative_close_denied
     ).start()
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers = {
             HTTPHeaders.TOKEN_ADDRESS: token_address,
             HTTPHeaders.CONTRACT_ADDRESS: channel_manager_address,
@@ -599,7 +614,7 @@ def test_error_handling(
         wraps=session.on_invalid_contract_address
     ).start()
 
-    with requests_mock.mock() as server_mock:
+    with requests_mock.mock(real_http=True) as server_mock:
         headers = {
             HTTPHeaders.TOKEN_ADDRESS: token_address,
             HTTPHeaders.CONTRACT_ADDRESS: channel_manager_address,

--- a/microraiden/microraiden/test/test_session.py
+++ b/microraiden/microraiden/test/test_session.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 import requests_mock
-from eth_utils import encode_hex
+from eth_utils import encode_hex, is_same_address
 from munch import Munch
 from requests import Response
 from requests.exceptions import SSLError
@@ -369,8 +369,8 @@ def test_session(
     assert channel == session.channel
     assert channel.balance_sig
     assert channel.balance < channel.deposit
-    assert channel.sender == sender_address
-    assert channel.receiver == receiver_address
+    assert is_same_address(channel.sender, sender_address)
+    assert is_same_address(channel.receiver, receiver_address)
 
 
 def test_session_topup(

--- a/microraiden/microraiden/test/test_session.py
+++ b/microraiden/microraiden/test/test_session.py
@@ -14,7 +14,6 @@ from web3 import Web3
 from microraiden import HTTPHeaders
 from microraiden import Session
 from microraiden.client import Channel
-from microraiden.test.utils.client import patch_on_http_response
 
 
 def check_response(response: Response):
@@ -483,11 +482,10 @@ def test_status_codes(
         session: Session,
         http_doggo_url: str
 ):
-    patch_on_http_response(session, abort_on=[404])
-    session.get(http_doggo_url)
-    assert session.last_response.status_code == 200
-    session.get(http_doggo_url[:-1])
-    assert session.last_response.status_code == 404
+    response = session.get(http_doggo_url)
+    assert response.status_code == 200
+    response = session.get(http_doggo_url[:-1])
+    assert response.status_code == 404
 
 
 def test_requests(

--- a/microraiden/microraiden/test/test_sqlite_types.py
+++ b/microraiden/microraiden/test/test_sqlite_types.py
@@ -1,9 +1,11 @@
 import logging
 import gevent
+import pytest
 
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skip("Current testnet-safe allowances don't allow for deposits of this size.")
 def test_big_deposit(channel_manager, client, receiver_address, wait_for_blocks):
     """Test if deposit of size bigger than int64 causes havoc when storing the state."""
     BIG_DEPOSIT = 10000000000000000000

--- a/microraiden/microraiden/test/test_version.py
+++ b/microraiden/microraiden/test/test_version.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 from web3 import Web3
 from web3.contract import Contract
@@ -31,11 +33,16 @@ def test_version(
         web3: Web3,
         channel_manager_contract: Contract,
         token_contract: Contract,
-        make_account
+        make_account,
+        private_keys: List[str]
 ):
     """Test if proxy refuses to run if it deployed contract version
     is different from the one it expects"""
-    receiver1_privkey = make_account(RECEIVER_ETH_ALLOWANCE, RECEIVER_TOKEN_ALLOWANCE)
+    receiver1_privkey = make_account(
+        RECEIVER_ETH_ALLOWANCE,
+        RECEIVER_TOKEN_ALLOWANCE,
+        private_keys[2]
+    )
 
     # this one should not raise
     cm = ChannelManager(

--- a/microraiden/microraiden/test/utils/client.py
+++ b/microraiden/microraiden/test/utils/client.py
@@ -1,10 +1,7 @@
-import types
-
 from eth_utils import is_same_address
-from requests import Response
 
 from microraiden.client import Channel
-from microraiden import Client, Session
+from microraiden import Client
 from microraiden.utils import privkey_to_addr, sign_close
 
 
@@ -39,4 +36,3 @@ def close_all_channels_cooperatively(
     ]
     for channel in channels:
         close_channel_cooperatively(channel, privkey_receiver, contract_address, balance)
-

--- a/microraiden/microraiden/test/utils/client.py
+++ b/microraiden/microraiden/test/utils/client.py
@@ -40,12 +40,3 @@ def close_all_channels_cooperatively(
     for channel in channels:
         close_channel_cooperatively(channel, privkey_receiver, contract_address, balance)
 
-
-def patch_on_http_response(default_http_client: Session, abort_on=[]):
-    def patched(self, method: str, url: str, response: Response, **kwargs):
-        self.last_response = response
-        return (response.status_code not in abort_on)
-    default_http_client.on_http_response = types.MethodType(
-        patched,
-        default_http_client
-    )

--- a/microraiden/microraiden/utils/contract.py
+++ b/microraiden/microraiden/utils/contract.py
@@ -23,7 +23,7 @@ def create_signed_transaction(
         data=b'',
         nonce_offset: int = 0,
         gas_price: int = GAS_PRICE,
-        gas_limit: int = GAS_LIMIT
+        gas_limit: int = 21000
 ) -> str:
     """
     Creates a signed on-chain transaction compliant with EIP155.
@@ -50,7 +50,7 @@ def create_transaction(
         nonce_offset: int = 0,
         value: int = 0,
         gas_price: int = GAS_PRICE,
-        gas_limit: int = GAS_LIMIT
+        gas_limit: int = 21000
 ) -> Transaction:
     nonce = web3.eth.getTransactionCount(from_, 'pending') + nonce_offset
     tx = Transaction(nonce, gas_price, gas_limit, to, value, data)
@@ -151,7 +151,7 @@ def get_event_blocking(
         contract: Contract,
         event_name: str,
         from_block: Union[int, str] = 0,
-        to_block: Union[int, str] = 'pending',
+        to_block: Union[int, str] = 'latest',
         argument_filters: Dict[str, Any]=None,
         condition=None,
         wait=DEFAULT_RETRY_INTERVAL,

--- a/microraiden/microraiden/utils/contract.py
+++ b/microraiden/microraiden/utils/contract.py
@@ -7,7 +7,7 @@ from ethereum.transactions import Transaction
 from web3 import Web3
 from web3.contract import Contract
 
-from microraiden.config import GAS_PRICE, GAS_LIMIT
+from microraiden.config import GAS_PRICE, GAS_LIMIT, POT_GAS_LIMIT
 from microraiden.utils import privkey_to_addr, sign_transaction
 from microraiden.utils.populus_compat import LogFilter
 
@@ -23,7 +23,7 @@ def create_signed_transaction(
         data=b'',
         nonce_offset: int = 0,
         gas_price: int = GAS_PRICE,
-        gas_limit: int = 21000
+        gas_limit: int = POT_GAS_LIMIT
 ) -> str:
     """
     Creates a signed on-chain transaction compliant with EIP155.
@@ -50,7 +50,7 @@ def create_transaction(
         nonce_offset: int = 0,
         value: int = 0,
         gas_price: int = GAS_PRICE,
-        gas_limit: int = 21000
+        gas_limit: int = POT_GAS_LIMIT
 ) -> Transaction:
     nonce = web3.eth.getTransactionCount(from_, 'pending') + nonce_offset
     tx = Transaction(nonce, gas_price, gas_limit, to, value, data)


### PR DESCRIPTION
This PR mainly introduces some compatibility changes and command line options to the test environment to properly run the tests on a real testnet (tested with Ropsten).

To run on the testnet:
* Start a testnet node on `localhost:8545`
* Pass `--no-tester` to `pytest`
* Pass `--faucet-private-key <key>` to `pytest` where `<key>` is either a hex-encoded private key or a path to a JSON file. This account will be used to fund transactions with ETH and testnet RDN tokens. Total transaction cost should be below 0.5 ETH. Remaining ETH and RDN will be returned to this address.
* If the faucet private key is a JSON file, make sure to pass `--faucet-password-path <path>` for a file containing the private key password.
* Optionally: Use a different tester private key generator seed with `--private-key-seed <int>` if you're scared of loss of funds or want to avoid collisions with simultaneously running tests.

This PR also includes several bug fixes encountered along the way, most of them having to do with the switch from `RPCProvider` to `HTTPProvider` and consistent use of checksummed addresses.

WIP: most tests still fail on testnet.