### PR TITLE
Automatically skip some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         - flake8 microraiden/
 
       script:
-          - coverage run --source microraiden/ --omit 'microraiden/microraiden/test/*,microraiden/microraiden/examples/*' -m py.test --populus-project 'contracts/' -k-needs_xorg --travis-fold=always -vvvvvvvvs $TEST_TYPE
+          - coverage run --source microraiden/ --omit 'microraiden/microraiden/test/*,microraiden/microraiden/examples/*' -m py.test --populus-project 'contracts/' --travis-fold=always -vvvvvvvvs $TEST_TYPE
 
       after_success:
         - coveralls

--- a/microraiden/microraiden/test/conftest.py
+++ b/microraiden/microraiden/test/conftest.py
@@ -2,10 +2,17 @@ from microraiden.test.fixtures import * # flake8: noqa
 from gevent import monkey
 monkey.patch_all(thread=False) # thread is false due to clash when testing both contract/microraiden modules
 import logging
+import os
 
 # to disable annoying 'test.rpc eth_getBlockNumber' message
 logging.getLogger('testrpc.rpc').setLevel(logging.WARNING)
 
+# test if both $DISPLAY and tkinter library are available
+try:
+    import tkinter
+    os.environ['DISPLAY']
+except (ImportError, KeyError):
+    os.environ['TEST_SKIP_XORG'] = '1'
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/microraiden/microraiden/test/test_examples.py
+++ b/microraiden/microraiden/test/test_examples.py
@@ -2,6 +2,7 @@ import pytest  # noqa: F401
 from _pytest.monkeypatch import MonkeyPatch
 from flask import jsonify
 from web3 import Web3
+import os
 
 from microraiden import Session
 from microraiden.channel_manager import ChannelManager
@@ -13,7 +14,10 @@ from microraiden.proxy.resources import PaywalledProxyUrl
 import microraiden.client.session
 
 
-@pytest.mark.needs_xorg
+@pytest.mark.skipif(
+    ('TEST_SKIP_XORG' in os.environ),
+    reason='requires Xorg'
+)
 def test_eth_ticker(
         empty_proxy: PaywalledProxy,
         session: Session,

--- a/microraiden/microraiden/test/test_sqlite_types.py
+++ b/microraiden/microraiden/test/test_sqlite_types.py
@@ -1,11 +1,18 @@
 import logging
 import gevent
 import pytest
+import os
 
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skip("Current testnet-safe allowances don't allow for deposits of this size.")
+@pytest.mark.skipif(
+    'TEST_SKIP_TESTNET' in os.environ,
+    reason="Current testnet-safe allowances don't allow for deposits of this size."
+)
+@pytest.mark.skip(
+    reason="Current test setup doesn't support custom allowance sizes for different networks"
+)
 def test_big_deposit(channel_manager, client, receiver_address, wait_for_blocks):
     """Test if deposit of size bigger than int64 causes havoc when storing the state."""
     BIG_DEPOSIT = 10000000000000000000


### PR DESCRIPTION
This currently covers tests that depend on xorg or testnet environment.
The big deposit test is skipped until we have separate test configurations for different networks.