### PR TITLE
Start syncing events from a specific block number

### DIFF
--- a/microraiden/microraiden/channel_manager/blockchain.py
+++ b/microraiden/microraiden/channel_manager/blockchain.py
@@ -41,6 +41,7 @@ class Blockchain(gevent.Greenlet):
         #  - used to dispute/close channels that are in CHALLENGED state after manager
         #     has ether to spend again
         self.insufficient_balance = False
+        self.sync_start_block = config.START_SYNC_BLOCK[self.web3.version.network]
 
     def _run(self):
         self.running = True
@@ -96,9 +97,9 @@ class Blockchain(gevent.Greenlet):
                 assert False  # unreachable as long as confirmation level is set high enough
 
         if self.cm.state.confirmed_head_number is None:
-            self.cm.state.update_sync_state(confirmed_head_number=-1)
+            self.cm.state.update_sync_state(confirmed_head_number=self.sync_start_block)
         if self.cm.state.unconfirmed_head_number is None:
-            self.cm.state.update_sync_state(unconfirmed_head_number=-1)
+            self.cm.state.update_sync_state(unconfirmed_head_number=self.sync_start_block)
         new_unconfirmed_head_number = self.cm.state.unconfirmed_head_number + self.sync_chunk_size
         new_unconfirmed_head_number = min(new_unconfirmed_head_number, current_block)
         new_confirmed_head_number = max(new_unconfirmed_head_number - self.n_confirmations, 0)

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -1,6 +1,7 @@
 import json
 import os
 from eth_utils import denoms
+from collections import namedtuple
 
 API_PATH = "/api/1"
 GAS_LIMIT = 130000
@@ -22,12 +23,22 @@ NETWORK_NAMES = {
     1337: 'geth'
 }
 
+NetworkConfig = namedtuple('NetworkConfig', 'channel_manager_address start_block')
+
 # address of the default channel manager contract. You can change this using commandline
 # option --channel-manager-address when running the proxy
+NETWORK_CONFIG = {
+    '1': NetworkConfig('0x0', 0),
+    '3': NetworkConfig('0x161a0d7726EB8B86EB587d8BD483be1CE87b0609', 2400640),
+    '42': NetworkConfig('0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400', 5230017)
+}
+# map NETWORK_CONFIG to a network_id: manager_address dict
 CHANNEL_MANAGER_ADDRESS = {
-    '1': '',
-    '3': '0x161a0d7726EB8B86EB587d8BD483be1CE87b0609',
-    '42': '0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400'
+    k: v.channel_manager_address for k, v in NETWORK_CONFIG.items()
+}
+# map NETWORK_CONFIG to a network_id: sync_block dict
+START_SYNC_BLOCK = {
+    k: v.start_block for k, v in NETWORK_CONFIG.items()
 }
 # absolute path to this directory. Used to find path to the webUI sources
 MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/microraiden/microraiden/proxy/resources/management.py
+++ b/microraiden/microraiden/proxy/resources/management.py
@@ -43,7 +43,8 @@ class ChannelManagementStats(Resource):
                 'contract_address': contract_address,
                 'receiver_address': self.channel_manager.receiver,
                 'manager_abi': self.channel_manager.channel_manager_contract.abi,
-                'token_abi': self.channel_manager.token_contract.abi
+                'token_abi': self.channel_manager.token_contract.abi,
+                'sync_block': self.channel_manager.blockchain.sync_start_block
                 }
 
 

--- a/microraiden/microraiden/test/test_rest_api.py
+++ b/microraiden/microraiden/test/test_rest_api.py
@@ -71,6 +71,7 @@ def test_stats(doggo_proxy: PaywalledProxy, api_endpoint_address):
     assert 'token_address' in stats
     assert 'receiver_address' in stats
     assert 'contract_address' in stats
+    assert stats['sync_block'] == doggo_proxy.channel_manager.blockchain.sync_start_block
     assert is_same_address(stats['receiver_address'], doggo_proxy.channel_manager.receiver)
     token_address = doggo_proxy.channel_manager.token_contract.address
     assert is_same_address(stats['token_address'], token_address)

--- a/microraiden/microraiden/webui/js/main.js
+++ b/microraiden/microraiden/webui/js/main.js
@@ -4,7 +4,7 @@ function mainSwitch(id) {
   $(".container").show();
 }
 
-function pageReady(contractABI, tokenABI) {
+function pageReady(contractABI, tokenABI, startBlock) {
 
   // ==== BASIC INITIALIZATION ====
 
@@ -22,6 +22,7 @@ function pageReady(contractABI, tokenABI) {
     contractABI,
     uRaidenParams.token,
     tokenABI,
+    startBlock,
   );
 
   // ==== MAIN VARIABLES ====
@@ -354,7 +355,7 @@ $(function() {
         setTimeout(function() { location.reload(); }, 5000);
       } else if (cnt <= 0 || window.web3) {
         clearInterval(pollingId);
-        pageReady(json['manager_abi'], json['token_abi']);
+        pageReady(json['manager_abi'], json['token_abi'], json['sync_block']);
       } else {
         --cnt;
       }

--- a/microraiden/microraiden/webui/microraiden/docs/README.md
+++ b/microraiden/microraiden/webui/microraiden/docs/README.md
@@ -84,6 +84,9 @@ Licensed under the [MIT License](./LICENSE)
 
 ### Interfaces
 
+* [ChannelCloseRequestedArgs](interfaces/channelcloserequestedargs.md)
+* [ChannelCreatedArgs](interfaces/channelcreatedargs.md)
+* [ChannelSettledArgs](interfaces/channelsettledargs.md)
 * [MicroChannel](interfaces/microchannel.md)
 * [MicroChannelInfo](interfaces/microchannelinfo.md)
 * [MicroProof](interfaces/microproof.md)
@@ -112,7 +115,7 @@ Licensed under the [MIT License](./LICENSE)
 
 **●  localStorage**:  *`any`* 
 
-*Defined in [index.ts:5](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L5)*
+*Defined in [index.ts:5](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L5)*
 
 
 
@@ -130,7 +133,7 @@ ___
 
 
 
-*Defined in [index.ts:133](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L133)*
+*Defined in [index.ts:159](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L159)*
 
 
 
@@ -165,7 +168,7 @@ ___
 
 
 
-*Defined in [index.ts:146](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L146)*
+*Defined in [index.ts:172](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L172)*
 
 
 
@@ -203,7 +206,7 @@ ___
 
 
 
-*Defined in [index.ts:109](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L109)*
+*Defined in [index.ts:135](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L135)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/classes/deferred.md
+++ b/microraiden/microraiden/webui/microraiden/docs/classes/deferred.md
@@ -30,7 +30,7 @@ Promise-based deferred class
     this.reject = reject;
   })
 
-*Defined in [index.ts:121](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L121)*
+*Defined in [index.ts:147](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L147)*
 
 
 
@@ -44,7 +44,7 @@ ___
 
 **●  reject**:  *`function`* 
 
-*Defined in [index.ts:120](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L120)*
+*Defined in [index.ts:146](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L146)*
 
 
 #### Type declaration
@@ -77,7 +77,7 @@ ___
 
 **●  resolve**:  *`function`* 
 
-*Defined in [index.ts:119](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L119)*
+*Defined in [index.ts:145](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L145)*
 
 
 #### Type declaration

--- a/microraiden/microraiden/webui/microraiden/docs/classes/microraiden.md
+++ b/microraiden/microraiden/webui/microraiden/docs/classes/microraiden.md
@@ -22,6 +22,7 @@ Contains all methods to interact with a MicroRaiden channel through a web3 insta
 * [channel](microraiden.md#channel)
 * [contract](microraiden.md#contract)
 * [decimals](microraiden.md#decimals)
+* [startBlock](microraiden.md#startblock)
 * [token](microraiden.md#token)
 * [web3](microraiden.md#web3)
 
@@ -58,10 +59,10 @@ Contains all methods to interact with a MicroRaiden channel through a web3 insta
 <a id="constructor"></a>
 
 
-### ⊕ **new MicroRaiden**(web3: *`string`⎮`object`*, contractAddr: *`string`*, contractABI: *`any`[]*, tokenAddr: *`string`*, tokenABI: *`any`[]*): [MicroRaiden](microraiden.md)
+### ⊕ **new MicroRaiden**(web3: *`string`⎮`object`*, contractAddr: *`string`*, contractABI: *`any`[]*, tokenAddr: *`string`*, tokenABI: *`any`[]*, startBlock?: *`number`*): [MicroRaiden](microraiden.md)
 
 
-*Defined in [index.ts:189](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L189)*
+*Defined in [index.ts:221](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L221)*
 
 
 
@@ -77,6 +78,7 @@ MicroRaiden constructor
 | contractABI | `any`[]   |  Channel manager ABI |
 | tokenAddr | `string`   |  Token address, must be the same setup in channel manager |
 | tokenABI | `any`[]   |  Token ABI |
+| startBlock | `number`   |  Block in which channel manager was deployed |
 
 
 
@@ -94,7 +96,7 @@ MicroRaiden constructor
 
 **●  challenge**:  *`number`* 
 
-*Defined in [index.ts:189](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L189)*
+*Defined in [index.ts:215](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L215)*
 
 
 
@@ -111,7 +113,7 @@ ___
 
 **●  channel**:  *[MicroChannel](../interfaces/microchannel.md)* 
 
-*Defined in [index.ts:173](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L173)*
+*Defined in [index.ts:199](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L199)*
 
 
 
@@ -128,7 +130,7 @@ ___
 
 **●  contract**:  *`Web3.ContractInstance`* 
 
-*Defined in [index.ts:181](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L181)*
+*Defined in [index.ts:207](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L207)*
 
 
 
@@ -145,11 +147,28 @@ ___
 
 **●  decimals**:  *`number`*  = 0
 
-*Defined in [index.ts:185](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L185)*
+*Defined in [index.ts:211](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L211)*
 
 
 
 Token decimals
+
+
+
+
+___
+
+<a id="startblock"></a>
+
+###  startBlock
+
+**●  startBlock**:  *`number`* 
+
+*Defined in [index.ts:221](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L221)*
+
+
+
+Block number in which channel manager was created, or before. Just a hint to avoid [loadChannelFromBlockchain](microraiden.md#loadchannelfromblockchain) to scan whole network for ChannelCreated events, default to 0
 
 
 
@@ -162,7 +181,7 @@ ___
 
 **●  token**:  *`Web3.ContractInstance`* 
 
-*Defined in [index.ts:177](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L177)*
+*Defined in [index.ts:203](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L203)*
 
 
 
@@ -179,7 +198,7 @@ ___
 
 **●  web3**:  *`Web3`* 
 
-*Defined in [index.ts:168](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L168)*
+*Defined in [index.ts:194](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L194)*
 
 
 
@@ -200,7 +219,7 @@ ___
 
 
 
-*Defined in [index.ts:1019](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L1019)*
+*Defined in [index.ts:1054](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L1054)*
 
 
 
@@ -235,7 +254,7 @@ ___
 
 
 
-*Defined in [index.ts:728](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L728)*
+*Defined in [index.ts:763](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L763)*
 
 
 
@@ -272,7 +291,7 @@ ___
 
 
 
-*Defined in [index.ts:944](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L944)*
+*Defined in [index.ts:979](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L979)*
 
 
 
@@ -307,7 +326,7 @@ ___
 
 
 
-*Defined in [index.ts:361](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L361)*
+*Defined in [index.ts:396](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L396)*
 
 
 
@@ -332,7 +351,7 @@ ___
 
 
 
-*Defined in [index.ts:491](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L491)*
+*Defined in [index.ts:526](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L526)*
 
 
 
@@ -359,7 +378,7 @@ ___
 
 
 
-*Defined in [index.ts:314](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L314)*
+*Defined in [index.ts:349](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L349)*
 
 
 
@@ -388,7 +407,7 @@ ___
 
 
 
-*Defined in [index.ts:521](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L521)*
+*Defined in [index.ts:556](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L556)*
 
 
 
@@ -423,7 +442,7 @@ ___
 
 
 
-*Defined in [index.ts:503](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L503)*
+*Defined in [index.ts:538](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L538)*
 
 
 
@@ -460,7 +479,7 @@ ___
 
 
 
-*Defined in [index.ts:918](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L918)*
+*Defined in [index.ts:953](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L953)*
 
 
 
@@ -497,7 +516,7 @@ ___
 
 
 
-*Defined in [index.ts:474](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L474)*
+*Defined in [index.ts:509](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L509)*
 
 
 
@@ -532,7 +551,7 @@ ___
 
 
 
-*Defined in [index.ts:384](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L384)*
+*Defined in [index.ts:419](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L419)*
 
 
 
@@ -570,7 +589,7 @@ ___
 
 
 
-*Defined in [index.ts:335](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L335)*
+*Defined in [index.ts:370](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L370)*
 
 
 
@@ -608,7 +627,7 @@ ___
 
 
 
-*Defined in [index.ts:232](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L232)*
+*Defined in [index.ts:267](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L267)*
 
 
 
@@ -645,7 +664,7 @@ ___
 
 
 
-*Defined in [index.ts:598](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L598)*
+*Defined in [index.ts:633](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L633)*
 
 
 
@@ -684,7 +703,7 @@ ___
 
 
 
-*Defined in [index.ts:968](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L968)*
+*Defined in [index.ts:1003](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L1003)*
 
 
 
@@ -719,7 +738,7 @@ ___
 
 
 
-*Defined in [index.ts:460](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L460)*
+*Defined in [index.ts:495](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L495)*
 
 
 
@@ -754,7 +773,7 @@ ___
 
 
 
-*Defined in [index.ts:782](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L782)*
+*Defined in [index.ts:817](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L817)*
 
 
 
@@ -781,7 +800,7 @@ ___
 
 
 
-*Defined in [index.ts:811](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L811)*
+*Defined in [index.ts:846](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L846)*
 
 
 
@@ -816,7 +835,7 @@ ___
 
 
 
-*Defined in [index.ts:849](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L849)*
+*Defined in [index.ts:884](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L884)*
 
 
 
@@ -853,7 +872,7 @@ ___
 
 
 
-*Defined in [index.ts:245](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L245)*
+*Defined in [index.ts:280](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L280)*
 
 
 
@@ -890,7 +909,7 @@ ___
 
 
 
-*Defined in [index.ts:667](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L667)*
+*Defined in [index.ts:702](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L702)*
 
 
 
@@ -927,7 +946,7 @@ ___
 
 
 
-*Defined in [index.ts:989](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L989)*
+*Defined in [index.ts:1024](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L1024)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/interfaces/microchannel.md
+++ b/microraiden/microraiden/webui/microraiden/docs/interfaces/microchannel.md
@@ -15,7 +15,7 @@
 
 **●  account**:  *`string`* 
 
-*Defined in [index.ts:31](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L31)*
+*Defined in [index.ts:31](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L31)*
 
 
 
@@ -32,7 +32,7 @@ ___
 
 **●  block**:  *`number`* 
 
-*Defined in [index.ts:39](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L39)*
+*Defined in [index.ts:39](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L39)*
 
 
 
@@ -49,7 +49,7 @@ ___
 
 **●  closing_sig**:  *`string`* 
 
-*Defined in [index.ts:51](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L51)*
+*Defined in [index.ts:51](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L51)*
 
 
 
@@ -66,7 +66,7 @@ ___
 
 **●  next_proof**:  *[MicroProof](microproof.md)* 
 
-*Defined in [index.ts:47](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L47)*
+*Defined in [index.ts:47](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L47)*
 
 
 
@@ -83,7 +83,7 @@ ___
 
 **●  proof**:  *[MicroProof](microproof.md)* 
 
-*Defined in [index.ts:43](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L43)*
+*Defined in [index.ts:43](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L43)*
 
 
 
@@ -100,7 +100,7 @@ ___
 
 **●  receiver**:  *`string`* 
 
-*Defined in [index.ts:35](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L35)*
+*Defined in [index.ts:35](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L35)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/interfaces/microchannelinfo.md
+++ b/microraiden/microraiden/webui/microraiden/docs/interfaces/microchannelinfo.md
@@ -15,7 +15,7 @@
 
 **●  block**:  *`number`* 
 
-*Defined in [index.ts:66](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L66)*
+*Defined in [index.ts:66](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L66)*
 
 
 
@@ -32,7 +32,7 @@ ___
 
 **●  deposit**:  *`BigNumber`* 
 
-*Defined in [index.ts:70](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L70)*
+*Defined in [index.ts:70](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L70)*
 
 
 
@@ -49,7 +49,7 @@ ___
 
 **●  state**:  *`string`* 
 
-*Defined in [index.ts:61](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L61)*
+*Defined in [index.ts:61](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L61)*
 
 
 
@@ -66,7 +66,7 @@ ___
 
 **●  withdrawn**:  *`BigNumber`* 
 
-*Defined in [index.ts:74](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L74)*
+*Defined in [index.ts:74](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L74)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/interfaces/microproof.md
+++ b/microraiden/microraiden/webui/microraiden/docs/interfaces/microproof.md
@@ -15,7 +15,7 @@
 
 **●  balance**:  *`BigNumber`* 
 
-*Defined in [index.ts:17](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L17)*
+*Defined in [index.ts:17](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L17)*
 
 
 
@@ -32,7 +32,7 @@ ___
 
 **●  sig**:  *`string`* 
 
-*Defined in [index.ts:21](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L21)*
+*Defined in [index.ts:21](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L21)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/interfaces/microtokeninfo.md
+++ b/microraiden/microraiden/webui/microraiden/docs/interfaces/microtokeninfo.md
@@ -15,7 +15,7 @@
 
 **●  balance**:  *`BigNumber`* 
 
-*Defined in [index.ts:84](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L84)*
+*Defined in [index.ts:84](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L84)*
 
 
 
@@ -29,7 +29,7 @@ ___
 
 **●  decimals**:  *`number`* 
 
-*Defined in [index.ts:83](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L83)*
+*Defined in [index.ts:83](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L83)*
 
 
 
@@ -43,7 +43,7 @@ ___
 
 **●  name**:  *`string`* 
 
-*Defined in [index.ts:81](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L81)*
+*Defined in [index.ts:81](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L81)*
 
 
 
@@ -57,7 +57,7 @@ ___
 
 **●  symbol**:  *`string`* 
 
-*Defined in [index.ts:82](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L82)*
+*Defined in [index.ts:82](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L82)*
 
 
 

--- a/microraiden/microraiden/webui/microraiden/docs/interfaces/msgparam.md
+++ b/microraiden/microraiden/webui/microraiden/docs/interfaces/msgparam.md
@@ -15,7 +15,7 @@ Array member type to be sent to eth_signTypedData
 
 **●  name**:  *`string`* 
 
-*Defined in [index.ts:92](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L92)*
+*Defined in [index.ts:92](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L92)*
 
 
 
@@ -29,7 +29,7 @@ ___
 
 **●  type**:  *`string`* 
 
-*Defined in [index.ts:91](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L91)*
+*Defined in [index.ts:91](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L91)*
 
 
 
@@ -43,7 +43,7 @@ ___
 
 **●  value**:  *`string`* 
 
-*Defined in [index.ts:93](https://github.com/raiden-network/microraiden/blob/89ba8a5/microraiden/microraiden/webui/microraiden/src/index.ts#L93)*
+*Defined in [index.ts:93](https://github.com/raiden-network/microraiden/blob/534ae10/microraiden/microraiden/webui/microraiden/src/index.ts#L93)*
 
 
 


### PR DESCRIPTION
A configuration with channel manager address and block number it was
deployed in is now available in `config.py`.
The block number is also exported via `/stats` REST endpoint to use in
js client etc.