### PR TITLE
Config gas price

### DIFF
--- a/microraiden/microraiden/channel_manager/blockchain.py
+++ b/microraiden/microraiden/channel_manager/blockchain.py
@@ -9,7 +9,8 @@ from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput
 from eth_utils import is_same_address, to_checksum_address
 
-import microraiden.config as config
+from microraiden.config import NETWORK_CFG
+from microraiden.constants import PROXY_BALANCE_LIMIT
 from microraiden.utils import get_logs
 
 
@@ -41,7 +42,7 @@ class Blockchain(gevent.Greenlet):
         #  - used to dispute/close channels that are in CHALLENGED state after manager
         #     has ether to spend again
         self.insufficient_balance = False
-        self.sync_start_block = config.START_SYNC_BLOCK[self.web3.version.network]
+        self.sync_start_block = NETWORK_CFG.start_sync_block
 
     def _run(self):
         self.running = True
@@ -290,7 +291,7 @@ class Blockchain(gevent.Greenlet):
 
     def insufficient_balance_recover(self):
         balance = self.web3.eth.getBalance(self.cm.receiver)
-        if balance < config.PROXY_BALANCE_LIMIT:
+        if balance < PROXY_BALANCE_LIMIT:
             return
         try:
             self.cm.close_pending_channels()

--- a/microraiden/microraiden/channel_manager/manager.py
+++ b/microraiden/microraiden/channel_manager/manager.py
@@ -32,7 +32,7 @@ from microraiden.exceptions import (
     InvalidContractVersion,
     NoBalanceProofReceived,
 )
-from microraiden.config import CHANNEL_MANAGER_CONTRACT_VERSION
+from microraiden.constants import CHANNEL_MANAGER_CONTRACT_VERSION
 from .state import ChannelManagerState
 from .blockchain import Blockchain
 from .channel import Channel, ChannelState

--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -13,7 +13,8 @@ from microraiden.utils import (
     create_signed_contract_transaction
 )
 
-from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
+import microraiden.config as config
+from microraiden.constants import WEB3_PROVIDER_DEFAULT
 from microraiden.client.context import Context
 from microraiden.client.channel import Channel
 
@@ -45,7 +46,7 @@ class Client:
             web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
 
         channel_manager_address = (
-            channel_manager_address or CHANNEL_MANAGER_ADDRESS[web3.version.network]
+            channel_manager_address or config.CHANNEL_MANAGER_ADDRESS
         )
 
         self.context = Context(private_key, web3, channel_manager_address)

--- a/microraiden/microraiden/client/context.py
+++ b/microraiden/microraiden/client/context.py
@@ -1,6 +1,6 @@
 from web3 import Web3
 
-from microraiden.config import CONTRACT_METADATA, TOKEN_ABI_NAME, CHANNEL_MANAGER_ABI_NAME
+from microraiden.constants import CONTRACT_METADATA, TOKEN_ABI_NAME, CHANNEL_MANAGER_ABI_NAME
 from microraiden.utils import privkey_to_addr
 
 

--- a/microraiden/microraiden/close_all_channels.py
+++ b/microraiden/microraiden/close_all_channels.py
@@ -15,10 +15,9 @@ from web3 import Web3, HTTPProvider
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput
 
-from microraiden import (
-    config,
-    utils,
-)
+from microraiden.constants import WEB3_PROVIDER_DEFAULT
+from microraiden.config import NETWORK_CFG
+from microraiden import utils
 from microraiden.channel_manager import ChannelManagerState
 from microraiden.utils import create_signed_contract_transaction, privkey_to_addr, sign_close
 from microraiden.exceptions import StateFileException
@@ -30,7 +29,7 @@ log = logging.getLogger('close_all_channels')
 @click.command()
 @click.option(
     '--rpc-provider',
-    default=config.WEB3_PROVIDER_DEFAULT,
+    default=WEB3_PROVIDER_DEFAULT,
     help='Address of the Ethereum RPC provider'
 )
 @click.option(
@@ -74,9 +73,10 @@ def main(
         state_file = os.path.join(app_dir, state_file_name)
 
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
+    NETWORK_CFG.set_defaults(int(web3.version.network))
     web3.eth.defaultAccount = receiver_address
     channel_manager_address = (
-        channel_manager_address or config.CHANNEL_MANAGER_ADDRESS[web3.version.network]
+        channel_manager_address or NETWORK_CFG.channel_manager_address
     )
     channel_manager_contract = make_channel_manager_contract(web3, channel_manager_address)
 

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -24,13 +24,17 @@ NetworkConfig = partial(
 # network-specific configuration
 NETWORK_CONFIG_DEFAULTS = {
     1: NetworkConfig(
-        channel_manager_address='0x0',
-        start_sync_block=0,
-        gas_price=50 * denoms.gwei
+        channel_manager_address='0x4d6e0922e6b703f0fdf92745343a9b83eb656402',
+        start_sync_block=4651176,
+        gas_price=20 * denoms.gwei
     ),
     3: NetworkConfig(
         channel_manager_address='0x161a0d7726EB8B86EB587d8BD483be1CE87b0609',
         start_sync_block=2400640
+    ),
+    4: NetworkConfig(
+        channel_manager_address='0x568a0d52a173f584d4a286a22b2a876911079e15',
+        start_sync_block=1338285
     ),
     42: NetworkConfig(
         channel_manager_address='0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400',

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -1,79 +1,61 @@
-import json
-import os
 from eth_utils import denoms
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
+from functools import partial
 
-API_PATH = "/api/1"
-GAS_LIMIT = 130000
 
-# Plain old transaction, for lack of a better term.
-POT_GAS_LIMIT = 21000
+# these are default values for network config
+network_config_defaults = OrderedDict(
+    (('channel_manager_address', None),
+     ('start_sync_block', 0),
+     ('gas_price', 20 * denoms.gwei),
+     ('gas_limit', 130000),
+     # pot = plain old transaction, for lack of better term
+     ('pot_gas_limit', 21000))
+)
+# create network config type that supports defaults
+NetworkConfig = partial(
+    namedtuple(
+        'NetworkConfig',
+        network_config_defaults
+    ),
+    **network_config_defaults
+)
 
-NETWORK_NAMES = {
-    1: 'mainnet',
-    2: 'morden',
-    3: 'ropsten',
-    4: 'rinkeby',
-    30: 'rootstock-main',
-    31: 'rootstock-test',
-    42: 'kovan',
-    61: 'etc-main',
-    62: 'etc-test',
-    1337: 'geth'
+# network-specific configuration
+NETWORK_CONFIG_DEFAULTS = {
+    1: NetworkConfig(
+        channel_manager_address='0x0',
+        start_sync_block=0
+    ),
+    3: NetworkConfig(
+        channel_manager_address='0x161a0d7726EB8B86EB587d8BD483be1CE87b0609',
+        start_sync_block=2400640
+    ),
+    42: NetworkConfig(
+        channel_manager_address='0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400',
+        start_sync_block=5230017
+    )
 }
 
-NetworkConfig = namedtuple('NetworkConfig', 'channel_manager_address start_block gas_price')
 
-# address of the default channel manager contract. You can change this using commandline
-# option --channel-manager-address when running the proxy
-NETWORK_CONFIG = {
-    '1': NetworkConfig('0x0', 0, 20 * denoms.gwei),
-    '3': NetworkConfig('0x161a0d7726EB8B86EB587d8BD483be1CE87b0609', 2400640, 20 * denoms.gwei),
-    '42': NetworkConfig('0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400', 5230017, 20 * denoms.gwei)
-}
-# map NETWORK_CONFIG to a network_id: manager_address dict
-CHANNEL_MANAGER_ADDRESS = {
-    k: v.channel_manager_address for k, v in NETWORK_CONFIG.items()
-}
-# map NETWORK_CONFIG to a network_id: sync_block dict
-START_SYNC_BLOCK = {
-    k: v.start_block for k, v in NETWORK_CONFIG.items()
-}
-# absolute path to this directory. Used to find path to the webUI sources
-MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-# webUI sources
-HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
-# javascript library for microraiden
-JSLIB_DIR = os.path.join(HTML_DIR, 'js')
-# url prefix for jslib dir
-JSPREFIX_URL = '/js'
-# decimals of the token. Any price that's set for the proxy resources is multiplied by this.
-TKN_DECIMALS = 10**18  # token decimals
+class NetworkRuntime:
+    def __init__(self):
+        super().__setattr__('cfg', None)
 
-# ethereum node RPC interface should be available here
-WEB3_PROVIDER_DEFAULT = "http://127.0.0.1:8545"
+    def set_defaults(self, network_id: int):
+        super().__setattr__('cfg', NETWORK_CONFIG_DEFAULTS[network_id])
 
-# name of the channel manager contract
-CHANNEL_MANAGER_ABI_NAME = 'RaidenMicroTransferChannels'
-# name of the token contract
-TOKEN_ABI_NAME = 'CustomToken'
-# compiled contracts path
-CONTRACTS_ABI_JSON = 'data/contracts.json'
+    def __getattr__(self, attr):
+        return self.cfg.__getattribute__(attr.lower())
 
-with open(os.path.join(MICRORAIDEN_DIR, 'microraiden', CONTRACTS_ABI_JSON)) as metadata_file:
-    CONTRACT_METADATA = json.load(metadata_file)
-
-# required version of the deployed contract at CHANNEL_MANAGER_ADDRESS.
-# Proxy will refuse to start if the versions do not match.
-MICRORAIDEN_VERSION = "0.1.1"
-CHANNEL_MANAGER_CONTRACT_VERSION = MICRORAIDEN_VERSION
-# they should stay the same until we decide otherwise
-assert MICRORAIDEN_VERSION == CHANNEL_MANAGER_CONTRACT_VERSION
-#  proxy will stop serving requests if receiver balance is below PROXY_BALANCE_LIMIT
-PROXY_BALANCE_LIMIT = 10**8
-SLEEP_RELOAD = 2
+    def __setattr__(self, attr, value):
+        return self.cfg.__setattribute__(attr.lower(), value)
 
 
-# sanity checks
-assert PROXY_BALANCE_LIMIT > 0
-assert isinstance(PROXY_BALANCE_LIMIT, int)
+def get_defaults(network_id: int):
+    return NETWORK_CONFIG_DEFAULTS[network_id]
+
+
+# default config is ropsten
+NETWORK_CFG = NetworkRuntime()
+NETWORK_CFG.set_defaults(3)

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -25,7 +25,8 @@ NetworkConfig = partial(
 NETWORK_CONFIG_DEFAULTS = {
     1: NetworkConfig(
         channel_manager_address='0x0',
-        start_sync_block=0
+        start_sync_block=0,
+        gas_price=50 * denoms.gwei
     ),
     3: NetworkConfig(
         channel_manager_address='0x161a0d7726EB8B86EB587d8BD483be1CE87b0609',
@@ -43,13 +44,14 @@ class NetworkRuntime:
         super().__setattr__('cfg', None)
 
     def set_defaults(self, network_id: int):
-        super().__setattr__('cfg', NETWORK_CONFIG_DEFAULTS[network_id])
+        cfg_copy = dict(NETWORK_CONFIG_DEFAULTS[network_id]._asdict())
+        super().__setattr__('cfg', cfg_copy)
 
     def __getattr__(self, attr):
-        return self.cfg.__getattribute__(attr.lower())
+        return self.cfg.__getitem__(attr.lower())
 
     def __setattr__(self, attr, value):
-        return self.cfg.__setattribute__(attr.lower(), value)
+        return self.cfg.__setitem__(attr.lower(), value)
 
 
 def get_defaults(network_id: int):

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -39,6 +39,10 @@ NETWORK_CONFIG_DEFAULTS = {
     42: NetworkConfig(
         channel_manager_address='0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400',
         start_sync_block=5230017
+    ),
+    65536: NetworkConfig(
+        channel_manager_address='0x0',
+        start_sync_block=0
     )
 }
 
@@ -55,6 +59,8 @@ class NetworkRuntime:
         return self.cfg.__getitem__(attr.lower())
 
     def __setattr__(self, attr, value):
+        if attr == 'cfg':
+            return super().__setattr__('cfg', value)
         return self.cfg.__setitem__(attr.lower(), value)
 
 

--- a/microraiden/microraiden/config.py
+++ b/microraiden/microraiden/config.py
@@ -8,7 +8,6 @@ GAS_LIMIT = 130000
 
 # Plain old transaction, for lack of a better term.
 POT_GAS_LIMIT = 21000
-GAS_PRICE = 20 * denoms.gwei
 
 NETWORK_NAMES = {
     1: 'mainnet',
@@ -23,14 +22,14 @@ NETWORK_NAMES = {
     1337: 'geth'
 }
 
-NetworkConfig = namedtuple('NetworkConfig', 'channel_manager_address start_block')
+NetworkConfig = namedtuple('NetworkConfig', 'channel_manager_address start_block gas_price')
 
 # address of the default channel manager contract. You can change this using commandline
 # option --channel-manager-address when running the proxy
 NETWORK_CONFIG = {
-    '1': NetworkConfig('0x0', 0),
-    '3': NetworkConfig('0x161a0d7726EB8B86EB587d8BD483be1CE87b0609', 2400640),
-    '42': NetworkConfig('0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400', 5230017)
+    '1': NetworkConfig('0x0', 0, 20 * denoms.gwei),
+    '3': NetworkConfig('0x161a0d7726EB8B86EB587d8BD483be1CE87b0609', 2400640, 20 * denoms.gwei),
+    '42': NetworkConfig('0xB9721dF0e024114e7B25F2cF503d8CBE3D52b400', 5230017, 20 * denoms.gwei)
 }
 # map NETWORK_CONFIG to a network_id: manager_address dict
 CHANNEL_MANAGER_ADDRESS = {

--- a/microraiden/microraiden/constants.py
+++ b/microraiden/microraiden/constants.py
@@ -1,0 +1,64 @@
+"""
+This file contains configuration constants you probably don't need to change
+"""
+import json
+import os
+
+# api path prefix
+API_PATH = "/api/1"
+# absolute path to this directory. Used to find path to the webUI sources
+MICRORAIDEN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# webUI sources
+HTML_DIR = os.path.join(MICRORAIDEN_DIR, 'microraiden', 'webui')
+# javascript library for microraiden
+JSLIB_DIR = os.path.join(HTML_DIR, 'js')
+# url prefix for jslib dir
+JSPREFIX_URL = '/js'
+# decimals of the token. Any price that's set for the proxy resources is multiplied by this.
+TKN_DECIMALS = 10**18  # token decimals
+
+# ethereum node RPC interface should be available here
+WEB3_PROVIDER_DEFAULT = "http://127.0.0.1:8545"
+
+# name of the channel manager contract
+CHANNEL_MANAGER_ABI_NAME = 'RaidenMicroTransferChannels'
+# name of the token contract
+TOKEN_ABI_NAME = 'CustomToken'
+# compiled contracts path
+CONTRACTS_ABI_JSON = 'data/contracts.json'
+
+with open(os.path.join(MICRORAIDEN_DIR, 'microraiden', CONTRACTS_ABI_JSON)) as metadata_file:
+    CONTRACT_METADATA = json.load(metadata_file)
+
+# required version of the deployed contract at CHANNEL_MANAGER_ADDRESS.
+# Proxy will refuse to start if the versions do not match.
+MICRORAIDEN_VERSION = "0.1.0"
+CHANNEL_MANAGER_CONTRACT_VERSION = MICRORAIDEN_VERSION
+# they should stay the same until we decide otherwise
+assert MICRORAIDEN_VERSION == CHANNEL_MANAGER_CONTRACT_VERSION
+#  proxy will stop serving requests if receiver balance is below PROXY_BALANCE_LIMIT
+PROXY_BALANCE_LIMIT = 10**8
+SLEEP_RELOAD = 2
+
+# sanity checks
+assert PROXY_BALANCE_LIMIT > 0
+assert isinstance(PROXY_BALANCE_LIMIT, int)
+
+# map network id to network name
+NETWORK_NAMES = {
+    1: 'mainnet',
+    2: 'morden',
+    3: 'ropsten',
+    4: 'rinkeby',
+    30: 'rootstock-main',
+    31: 'rootstock-test',
+    42: 'kovan',
+    61: 'etc-main',
+    62: 'etc-test',
+    1337: 'geth'
+}
+
+
+def get_network_id(network_name: str):
+    ids = list(NETWORK_NAMES.keys())
+    return ids[list(NETWORK_NAMES.values()).index(network_name)]

--- a/microraiden/microraiden/constants.py
+++ b/microraiden/microraiden/constants.py
@@ -53,7 +53,9 @@ NETWORK_NAMES = {
     42: 'kovan',
     61: 'etc-main',
     62: 'etc-test',
-    1337: 'geth'
+    1337: 'geth',
+
+    65536: 'ethereum-tester'
 }
 
 

--- a/microraiden/microraiden/constants.py
+++ b/microraiden/microraiden/constants.py
@@ -32,10 +32,8 @@ with open(os.path.join(MICRORAIDEN_DIR, 'microraiden', CONTRACTS_ABI_JSON)) as m
 
 # required version of the deployed contract at CHANNEL_MANAGER_ADDRESS.
 # Proxy will refuse to start if the versions do not match.
-MICRORAIDEN_VERSION = "0.1.0"
-CHANNEL_MANAGER_CONTRACT_VERSION = MICRORAIDEN_VERSION
-# they should stay the same until we decide otherwise
-assert MICRORAIDEN_VERSION == CHANNEL_MANAGER_CONTRACT_VERSION
+MICRORAIDEN_VERSION = "0.1.1"
+CHANNEL_MANAGER_CONTRACT_VERSION = "0.1.0"
 #  proxy will stop serving requests if receiver balance is below PROXY_BALANCE_LIMIT
 PROXY_BALANCE_LIMIT = 10**8
 SLEEP_RELOAD = 2

--- a/microraiden/microraiden/examples/demo_proxy/__main__.py
+++ b/microraiden/microraiden/examples/demo_proxy/__main__.py
@@ -4,7 +4,7 @@ import logging
 from flask import send_file
 
 from microraiden.click_helpers import main, pass_app
-from microraiden.config import TKN_DECIMALS
+from microraiden.constants import TKN_DECIMALS
 from microraiden.examples.demo_resources import (
     PaywalledDoggo,
     PaywalledFortune,

--- a/microraiden/microraiden/examples/echo_server.py
+++ b/microraiden/microraiden/examples/echo_server.py
@@ -10,7 +10,8 @@ from web3 import Web3, HTTPProvider
 
 from microraiden.channel_manager import ChannelManager
 from microraiden.make_helpers import make_channel_manager
-from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
+from microraiden.constants import WEB3_PROVIDER_DEFAULT
+from microraiden.config import NETWORK_CFG
 from microraiden.proxy import PaywalledProxy
 from microraiden.proxy.resources import Expensive
 from microraiden.utils import get_private_key
@@ -62,9 +63,10 @@ def run(
     #  - file for storing state information (balance proofs)
     if channel_manager is None:
         web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
+        NETWORK_CFG.set_defaults(web3.version.network)
         channel_manager = make_channel_manager(
             private_key,
-            CHANNEL_MANAGER_ADDRESS[web3.version.network],
+            NETWORK_CFG.CHANNEL_MANAGER_ADDRESS,
             state_file_path,
             web3
         )

--- a/microraiden/microraiden/make_helpers.py
+++ b/microraiden/microraiden/make_helpers.py
@@ -10,7 +10,8 @@ from microraiden.exceptions import (
     StateReceiverAddrMismatch,
     StateContractAddrMismatch
 )
-from microraiden import config
+from microraiden import constants
+from microraiden.config import NETWORK_CFG
 from microraiden.proxy.paywalled_proxy import PaywalledProxy
 
 log = logging.getLogger(__name__)
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 
 def make_channel_manager_contract(web3: Web3, channel_manager_address: str) -> Contract:
     return web3.eth.contract(
-        abi=config.CONTRACT_METADATA[config.CHANNEL_MANAGER_ABI_NAME]['abi'],
+        abi=constants.CONTRACT_METADATA[constants.CHANNEL_MANAGER_ABI_NAME]['abi'],
         address=channel_manager_address
     )
 
@@ -32,7 +33,7 @@ def make_channel_manager(
     channel_manager_address = to_checksum_address(channel_manager_address)
     channel_manager_contract = make_channel_manager_contract(web3, channel_manager_address)
     token_address = channel_manager_contract.call().token()
-    token_abi = config.CONTRACT_METADATA[config.TOKEN_ABI_NAME]['abi']
+    token_abi = constants.CONTRACT_METADATA[constants.TOKEN_ABI_NAME]['abi']
     token_contract = web3.eth.contract(abi=token_abi, address=token_address)
     try:
         return ChannelManager(
@@ -67,8 +68,8 @@ def make_paywalled_proxy(
         web3=None
 ) -> PaywalledProxy:
     if web3 is None:
-        web3 = Web3(HTTPProvider(config.WEB3_PROVIDER_DEFAULT, request_kwargs={'timeout': 60}))
-        contract_address = contract_address or config.CHANNEL_MANAGER_ADDRESS[web3.version.network]
+        web3 = Web3(HTTPProvider(constants.WEB3_PROVIDER_DEFAULT, request_kwargs={'timeout': 60}))
+        contract_address = contract_address or NETWORK_CFG.CHANNEL_MANAGER_ADDRESS
     channel_manager = make_channel_manager(private_key, contract_address, state_filename, web3)
-    proxy = PaywalledProxy(channel_manager, flask_app, config.HTML_DIR, config.JSLIB_DIR)
+    proxy = PaywalledProxy(channel_manager, flask_app, constants.HTML_DIR, constants.JSLIB_DIR)
     return proxy

--- a/microraiden/microraiden/proxy/paywalled_proxy.py
+++ b/microraiden/microraiden/proxy/paywalled_proxy.py
@@ -5,7 +5,6 @@ from flask_restful import (
     Api,
 )
 
-from microraiden import config
 
 from microraiden.channel_manager import (
     ChannelManager
@@ -24,7 +23,7 @@ from microraiden.proxy.resources import (
 )
 
 from microraiden.proxy.resources.expensive import LightClientProxy
-from microraiden.config import API_PATH
+from microraiden.constants import API_PATH, HTML_DIR, JSLIB_DIR, JSPREFIX_URL
 from microraiden.proxy.resources.paywall_decorator import Paywall
 
 
@@ -45,15 +44,15 @@ class PaywalledProxy:
         #  this doesn't work atm, due to test teardown problems
         #  it's not a critical error, but it should be fixed
         #  gevent.get_hub().SYSTEM_ERROR += (BaseException, )
-        paywall_html_dir = paywall_html_dir or config.HTML_DIR
-        paywall_js_dir = paywall_js_dir or config.JSLIB_DIR
+        paywall_html_dir = paywall_html_dir or HTML_DIR
+        paywall_js_dir = paywall_js_dir or JSLIB_DIR
         assert isinstance(channel_manager, ChannelManager)
         assert isinstance(paywall_html_dir, str)
 
         if not flask_app:
             self.app = Flask(
                 __name__,
-                static_url_path=config.JSPREFIX_URL,
+                static_url_path=JSPREFIX_URL,
                 static_folder=paywall_js_dir
             )
         else:

--- a/microraiden/microraiden/proxy/resources/paywall_decorator.py
+++ b/microraiden/microraiden/proxy/resources/paywall_decorator.py
@@ -14,7 +14,7 @@ from microraiden.exceptions import (
     InvalidBalanceAmount,
     InsufficientConfirmations
 )
-import microraiden.config as config
+import microraiden.constants as constants
 from functools import wraps
 from eth_utils import is_address
 
@@ -106,7 +106,7 @@ class Paywall(object):
     def access(self, resource, method, *args, **kwargs):
         if self.channel_manager.node_online() is False:
             return "Ethereum node is not responding", 502
-        if self.channel_manager.get_eth_balance() < config.PROXY_BALANCE_LIMIT:
+        if self.channel_manager.get_eth_balance() < constants.PROXY_BALANCE_LIMIT:
             return "Channel manager ETH balance is below limit", 502
         try:
             data = RequestData(request.headers, request.cookies)
@@ -224,7 +224,7 @@ class Paywall(object):
         assert price > 0
         """Generate basic headers that are sent back for every request"""
         headers = {
-            header.GATEWAY_PATH: config.API_PATH,
+            header.GATEWAY_PATH: constants.API_PATH,
             header.RECEIVER_ADDRESS: self.receiver_address,
             header.CONTRACT_ADDRESS: self.contract_address,
             header.TOKEN_ADDRESS: self.channel_manager.get_token_address(),

--- a/microraiden/microraiden/proxy/resources/proxy_url.py
+++ b/microraiden/microraiden/proxy/resources/proxy_url.py
@@ -5,7 +5,7 @@ import requests
 import logging
 from flask import Response, stream_with_context, request
 
-from microraiden.config import MICRORAIDEN_DIR
+from microraiden.constants import MICRORAIDEN_DIR
 
 log = logging.getLogger(__name__)
 

--- a/microraiden/microraiden/test/conftest.py
+++ b/microraiden/microraiden/test/conftest.py
@@ -3,6 +3,9 @@ from gevent import monkey
 monkey.patch_all(thread=False) # thread is false due to clash when testing both contract/microraiden modules
 import logging
 import os
+import microraiden.config as config
+
+config.START_SYNC_BLOCK = 0
 
 # to disable annoying 'test.rpc eth_getBlockNumber' message
 logging.getLogger('testrpc.rpc').setLevel(logging.WARNING)

--- a/microraiden/microraiden/test/fixtures/accounts.py
+++ b/microraiden/microraiden/test/fixtures/accounts.py
@@ -20,7 +20,7 @@ from microraiden.utils import (
     create_signed_transaction,
     get_private_key
 )
-from microraiden.config import GAS_PRICE, POT_GAS_LIMIT
+from microraiden.config import NETWORK_CFG
 from microraiden.test.config import (
     RECEIVER_ETH_ALLOWANCE,
     RECEIVER_TOKEN_ALLOWANCE,
@@ -168,14 +168,14 @@ def sweep_account(
             assert token_contract.call().balanceOf(address) == 0
 
     balance = web3.eth.getBalance(address)
-    if balance < POT_GAS_LIMIT * GAS_PRICE:
+    if balance < NETWORK_CFG.POT_GAS_LIMIT * NETWORK_CFG.GAS_PRICE:
         return
     tx = create_signed_transaction(
         private_key,
         web3,
         to=faucet_address,
-        value=balance - POT_GAS_LIMIT * GAS_PRICE,
-        gas_limit=POT_GAS_LIMIT
+        value=balance - NETWORK_CFG.POT_GAS_LIMIT * NETWORK_CFG.GAS_PRICE,
+        gas_limit=NETWORK_CFG.POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)

--- a/microraiden/microraiden/test/fixtures/variables.py
+++ b/microraiden/microraiden/test/fixtures/variables.py
@@ -33,7 +33,7 @@ def proxy_ssl_certs(test_dir):
 def use_tester(request):
     is_tester = request.config.getoption('use_tester')
     if is_tester is True:
-        NETWORK_CFG.set_defaults(get_network_id('mainnet'))
+        NETWORK_CFG.set_defaults(get_network_id('ethereum-tester'))
     return is_tester
 
 

--- a/microraiden/microraiden/test/fixtures/variables.py
+++ b/microraiden/microraiden/test/fixtures/variables.py
@@ -5,7 +5,13 @@ from ethereum.tester import keys
 import os
 import json
 from microraiden.utils import privkey_to_addr
-from microraiden.config import CONTRACTS_ABI_JSON, CHANNEL_MANAGER_ABI_NAME, TOKEN_ABI_NAME
+from microraiden.config import NETWORK_CFG
+from microraiden.constants import (
+    CONTRACTS_ABI_JSON,
+    CHANNEL_MANAGER_ABI_NAME,
+    TOKEN_ABI_NAME,
+    get_network_id
+)
 
 
 @pytest.fixture
@@ -25,7 +31,10 @@ def proxy_ssl_certs(test_dir):
 
 @pytest.fixture(scope='session')
 def use_tester(request):
-    return request.config.getoption('use_tester')
+    is_tester = request.config.getoption('use_tester')
+    if is_tester is True:
+        NETWORK_CFG.set_defaults(get_network_id('mainnet'))
+    return is_tester
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -171,6 +171,7 @@ def web3(use_tester: bool, faucet_private_key: str, faucet_address: str, mine_sy
     else:
         rpc = HTTPProvider(WEB3_PROVIDER_DEFAULT)
         web3 = Web3(rpc)
+        NETWORK_CFG.set_defaults(int(web3.version.network))
 
     yield web3
 

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -14,7 +14,8 @@ from web3 import Web3, EthereumTesterProvider
 from web3.contract import Contract
 from web3.providers.rpc import HTTPProvider
 
-from microraiden.config import CHANNEL_MANAGER_ADDRESS, WEB3_PROVIDER_DEFAULT
+from microraiden.config import NETWORK_CFG
+from microraiden.constants import WEB3_PROVIDER_DEFAULT
 from microraiden.utils import (
     addr_from_sig,
     keccak256,
@@ -73,7 +74,7 @@ def token_address(
     else:
         channel_manager = web3.eth.contract(
             abi=channel_manager_abi,
-            address=CHANNEL_MANAGER_ADDRESS[web3.version.network]
+            address=NETWORK_CFG.CHANNEL_MANAGER_ADDRESS
         )
         return channel_manager.call().token()
 
@@ -112,7 +113,7 @@ def channel_manager_address(
         )
         return contract.address
     else:
-        return CHANNEL_MANAGER_ADDRESS[web3.version.network]
+        return NETWORK_CFG.CHANNEL_MANAGER_ADDRESS
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/test_broke_proxy.py
+++ b/microraiden/microraiden/test/test_broke_proxy.py
@@ -1,5 +1,5 @@
 from microraiden import Session
-from microraiden.config import GAS_PRICE, POT_GAS_LIMIT
+from microraiden.config import NETWORK_CFG
 from microraiden.utils import create_signed_transaction
 
 
@@ -21,7 +21,7 @@ def test_cheating_client(
         receiver_privkey,
         web3,
         faucet_address,
-        balance - GAS_PRICE * POT_GAS_LIMIT
+        balance - NETWORK_CFG.GAS_PRICE * NETWORK_CFG.POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)
@@ -32,7 +32,7 @@ def test_cheating_client(
         faucet_private_key,
         web3,
         receiver_address,
-        balance - GAS_PRICE * POT_GAS_LIMIT
+        balance - NETWORK_CFG.GAS_PRICE * NETWORK_CFG.POT_GAS_LIMIT
     )
     tx_hash = web3.eth.sendRawTransaction(tx)
     wait_for_transaction(tx_hash)

--- a/microraiden/microraiden/test/test_client.py
+++ b/microraiden/microraiden/test/test_client.py
@@ -29,6 +29,7 @@ def test_client(client: Client, receiver_address):
 
 def test_cooperative_close(client: Client, receiver_privkey, receiver_address):
     c = client.get_suitable_channel(receiver_address, 3)
+    assert c is not None
     c.create_transfer(3)
 
     assert c.deposit >= 3
@@ -47,6 +48,7 @@ def test_cooperative_close(client: Client, receiver_privkey, receiver_address):
 
 def test_integrity(client: Client, receiver_address):
     c = client.get_suitable_channel(receiver_address, 5)
+    assert c is not None
     assert c.balance == 0
     assert c.balance_sig == sign_balance_proof(
         client.context.private_key,
@@ -76,6 +78,7 @@ def test_integrity(client: Client, receiver_address):
 
 def test_sync(client: Client, receiver_address, receiver_privkey):
     c = client.get_suitable_channel(receiver_address, 5, initial_deposit=lambda x: x)
+    assert c is not None
     assert c in client.channels
     assert c.deposit == 5
     assert len(client.channels) == 1
@@ -87,6 +90,7 @@ def test_sync(client: Client, receiver_address, receiver_privkey):
 
     # Check if client handles topup events on sync.
     c_topup = client.get_suitable_channel(receiver_address, 7, topup_deposit=lambda x: 2)
+    assert c is not None
     assert c_topup == c
     assert len(client.channels) == 1
     assert c.deposit == 7
@@ -117,6 +121,7 @@ def test_open_channel_insufficient_tokens(client: Client, web3: Web3, receiver_a
 def test_topup_channel_insufficient_tokens(client: Client, web3: Web3, receiver_address: str):
     balance_of = client.context.token.call().balanceOf(client.context.address)
     channel = client.open_channel(receiver_address, 1)
+    assert channel is not None
 
     tx_count_pre = web3.eth.getTransactionCount(client.context.address)
     assert channel.topup(balance_of) is None

--- a/microraiden/microraiden/test/test_network_config.py
+++ b/microraiden/microraiden/test/test_network_config.py
@@ -8,6 +8,9 @@ def test_network_config():
     mainnet_gas_price = NETWORK_CONFIG_DEFAULTS[1].gas_price
     ropsten_gas_price = NETWORK_CONFIG_DEFAULTS[3].gas_price
 
+    # don't forget to restore existing network config
+    old_cfg = NETWORK_CFG.cfg
+
     NETWORK_CFG.set_defaults(1)
     assert NETWORK_CFG.gas_price == mainnet_gas_price
     NETWORK_CFG.gas_price = TEST_GAS_PRICE
@@ -17,8 +20,11 @@ def test_network_config():
     NETWORK_CFG.set_defaults(3)
     assert NETWORK_CFG.gas_price == ropsten_gas_price
 
+    NETWORK_CFG.cfg = old_cfg
+
 
 def test_transaction_params(web3):
+    old_cfg = NETWORK_CFG.cfg
     NETWORK_CFG.set_defaults(1)
     addr1 = '0x0000000000000000000000000000000000000001'
     addr2 = '0x0000000000000000000000000000000000000002'
@@ -27,3 +33,4 @@ def test_transaction_params(web3):
     NETWORK_CFG.gas_price = TEST_GAS_PRICE
     tx = create_transaction(web3, addr1, addr2)
     assert tx.gasprice == TEST_GAS_PRICE
+    NETWORK_CFG.cfg = old_cfg

--- a/microraiden/microraiden/test/test_network_config.py
+++ b/microraiden/microraiden/test/test_network_config.py
@@ -1,0 +1,29 @@
+from microraiden.config import NETWORK_CFG, NETWORK_CONFIG_DEFAULTS
+from microraiden.utils.contract import create_transaction
+
+TEST_GAS_PRICE = 123456
+
+
+def test_network_config():
+    mainnet_gas_price = NETWORK_CONFIG_DEFAULTS[1].gas_price
+    ropsten_gas_price = NETWORK_CONFIG_DEFAULTS[3].gas_price
+
+    NETWORK_CFG.set_defaults(1)
+    assert NETWORK_CFG.gas_price == mainnet_gas_price
+    NETWORK_CFG.gas_price = TEST_GAS_PRICE
+    assert NETWORK_CFG.gas_price == TEST_GAS_PRICE
+    NETWORK_CFG.set_defaults(1)
+    assert NETWORK_CFG.gas_price == mainnet_gas_price
+    NETWORK_CFG.set_defaults(3)
+    assert NETWORK_CFG.gas_price == ropsten_gas_price
+
+
+def test_transaction_params(web3):
+    NETWORK_CFG.set_defaults(1)
+    addr1 = '0x0000000000000000000000000000000000000001'
+    addr2 = '0x0000000000000000000000000000000000000002'
+    tx = create_transaction(web3, addr1, addr2)
+    assert tx.gasprice == NETWORK_CFG.gas_price
+    NETWORK_CFG.gas_price = TEST_GAS_PRICE
+    tx = create_transaction(web3, addr1, addr2)
+    assert tx.gasprice == TEST_GAS_PRICE

--- a/microraiden/microraiden/test/test_rest_api.py
+++ b/microraiden/microraiden/test/test_rest_api.py
@@ -4,7 +4,7 @@ import json
 import gevent
 
 from eth_utils import is_same_address
-from microraiden.config import API_PATH
+from microraiden.constants import API_PATH
 from microraiden.proxy.paywalled_proxy import PaywalledProxy
 
 

--- a/microraiden/microraiden/utils/contract.py
+++ b/microraiden/microraiden/utils/contract.py
@@ -22,12 +22,14 @@ def create_signed_transaction(
         value: int=0,
         data=b'',
         nonce_offset: int = 0,
-        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_price: Union[int, None] = None,
         gas_limit: int = NETWORK_CFG.POT_GAS_LIMIT
 ) -> str:
     """
     Creates a signed on-chain transaction compliant with EIP155.
     """
+    if gas_price is None:
+        gas_price = NETWORK_CFG.GAS_PRICE
     tx = create_transaction(
         web3=web3,
         from_=privkey_to_addr(private_key),
@@ -49,9 +51,11 @@ def create_transaction(
         data: bytes = b'',
         nonce_offset: int = 0,
         value: int = 0,
-        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_price: Union[int, None] = None,
         gas_limit: int = NETWORK_CFG.POT_GAS_LIMIT
 ) -> Transaction:
+    if gas_price is None:
+        gas_price = NETWORK_CFG.GAS_PRICE
     nonce = web3.eth.getTransactionCount(from_, 'pending') + nonce_offset
     tx = Transaction(nonce, gas_price, gas_limit, to, value, data)
     tx.sender = decode_hex(from_)
@@ -65,12 +69,14 @@ def create_signed_contract_transaction(
         args: List[Any],
         value: int=0,
         nonce_offset: int = 0,
-        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_price: Union[int, None] = None,
         gas_limit: int = NETWORK_CFG.GAS_LIMIT
 ) -> str:
     """
     Creates a signed on-chain contract transaction compliant with EIP155.
     """
+    if gas_price is None:
+        gas_price = NETWORK_CFG.GAS_PRICE
     tx = create_contract_transaction(
         contract=contract,
         from_=privkey_to_addr(private_key),
@@ -92,9 +98,11 @@ def create_contract_transaction(
         args: List[Any],
         value: int = 0,
         nonce_offset: int = 0,
-        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_price: Union[int, None] = None,
         gas_limit: int = NETWORK_CFG.GAS_LIMIT
 ) -> Transaction:
+    if gas_price is None:
+        gas_price = NETWORK_CFG.GAS_PRICE
     data = create_transaction_data(contract, func_name, args)
     return create_transaction(
         web3=contract.web3,

--- a/microraiden/microraiden/utils/contract.py
+++ b/microraiden/microraiden/utils/contract.py
@@ -7,7 +7,7 @@ from ethereum.transactions import Transaction
 from web3 import Web3
 from web3.contract import Contract
 
-from microraiden.config import GAS_PRICE, GAS_LIMIT, POT_GAS_LIMIT
+from microraiden.config import NETWORK_CFG
 from microraiden.utils import privkey_to_addr, sign_transaction
 from microraiden.utils.populus_compat import LogFilter
 
@@ -22,8 +22,8 @@ def create_signed_transaction(
         value: int=0,
         data=b'',
         nonce_offset: int = 0,
-        gas_price: int = GAS_PRICE,
-        gas_limit: int = POT_GAS_LIMIT
+        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_limit: int = NETWORK_CFG.POT_GAS_LIMIT
 ) -> str:
     """
     Creates a signed on-chain transaction compliant with EIP155.
@@ -49,8 +49,8 @@ def create_transaction(
         data: bytes = b'',
         nonce_offset: int = 0,
         value: int = 0,
-        gas_price: int = GAS_PRICE,
-        gas_limit: int = POT_GAS_LIMIT
+        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_limit: int = NETWORK_CFG.POT_GAS_LIMIT
 ) -> Transaction:
     nonce = web3.eth.getTransactionCount(from_, 'pending') + nonce_offset
     tx = Transaction(nonce, gas_price, gas_limit, to, value, data)
@@ -65,8 +65,8 @@ def create_signed_contract_transaction(
         args: List[Any],
         value: int=0,
         nonce_offset: int = 0,
-        gas_price: int = GAS_PRICE,
-        gas_limit: int = GAS_LIMIT
+        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_limit: int = NETWORK_CFG.GAS_LIMIT
 ) -> str:
     """
     Creates a signed on-chain contract transaction compliant with EIP155.
@@ -92,8 +92,8 @@ def create_contract_transaction(
         args: List[Any],
         value: int = 0,
         nonce_offset: int = 0,
-        gas_price: int = GAS_PRICE,
-        gas_limit: int = GAS_LIMIT
+        gas_price: int = NETWORK_CFG.GAS_PRICE,
+        gas_limit: int = NETWORK_CFG.GAS_LIMIT
 ) -> Transaction:
     data = create_transaction_data(contract, func_name, args)
     return create_transaction(


### PR DESCRIPTION
This PR makes it possible to configure network-related variables.
These include

- channel manager address
- start sync block
- gas price
- gas limit
- pot_gas_limit

I've moved most of the stuff from `config.py` to `constants.py`, as these are generally things that don't need frequent changes. `config.py` now includes network configuration and exports a global: `NETWORK_CFG` 

Also fixes #354 