### PR TITLE
Remove deposit limit

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -22,12 +22,6 @@ contract RaidenMicroTransferChannels {
     // Contract semantic version
     string public constant version = '0.1.0';
 
-    // We temporarily limit total token deposits in a channel to 100 tokens with 18 decimals.
-    // This was calculated just for RDN with its current (as of 30/11/2017) price and should
-    // not be considered to be the same for other tokens.
-    // This is just for the bug bounty release, as a safety measure.
-    uint256 public constant channel_deposit_bugbounty_limit = 10 ** 18 * 100;
-
     Token public token;
 
     mapping (bytes32 => Channel) public channels;
@@ -568,8 +562,6 @@ contract RaidenMicroTransferChannels {
         uint192 _deposit)
         private
     {
-        require(_deposit <= channel_deposit_bugbounty_limit);
-
         uint32 open_block_number = uint32(block.number);
 
         // Create unique identifier from sender, receiver and current block number
@@ -604,7 +596,6 @@ contract RaidenMicroTransferChannels {
 
         require(channels[key].open_block_number > 0);
         require(closing_requests[key].settle_block_number == 0);
-        require(channels[key].deposit + _added_deposit <= channel_deposit_bugbounty_limit);
 
         channels[key].deposit += _added_deposit;
         assert(channels[key].deposit >= _added_deposit);

--- a/contracts/tests/fixtures.py
+++ b/contracts/tests/fixtures.py
@@ -3,18 +3,13 @@ from utils.logs import LogHandler
 
 
 print_the_logs = False
-
-
 MAX_UINT256 = 2 ** 256 - 1
 MAX_UINT192 = 2 ** 192 - 1
 MAX_UINT32 = 2 ** 32 - 1
 fake_address = '0x03432'
 empty_address = '0x0000000000000000000000000000000000000000'
 passphrase = '0'
-
-# recheck test_create_token_fallback_uint_conversion when bug bounty limit is removed
 uraiden_contract_version = '0.1.0'
-channel_deposit_bugbounty_limit = 100 * 10 ** 18
 challenge_period_min = 500
 contract_args = [
     {
@@ -45,8 +40,6 @@ channel_values = [
         'type': '223'
     }
 ]
-
-
 uraiden_events = {
     'created': 'ChannelCreated',
     'topup': 'ChannelToppedUp',

--- a/contracts/tests/test_channel_topup.py
+++ b/contracts/tests/test_channel_topup.py
@@ -1,7 +1,6 @@
 import pytest
 from ethereum import tester
 from tests.fixtures import (
-    channel_deposit_bugbounty_limit,
     contract_params,
     channel_params,
     owner_index,
@@ -76,55 +75,6 @@ def test_channel_topup_223(
     ev_handler.check()
 
 
-def test_channel_topup_223_bounty_limit(
-    get_accounts,
-    owner,
-    uraiden_instance,
-    token_instance,
-    get_channel):
-    token = token_instance
-    (sender, receiver, A) = get_accounts(3)
-    channel_deposit = 1
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
-    (sender, receiver, open_block_number) = channel
-
-    top_up_data = sender[2:] + receiver[2:] + hex(open_block_number)[2:].zfill(8)
-    top_up_data = bytes.fromhex(top_up_data)
-
-    # See how many tokens we need to reach channel_deposit_bugbounty_limit
-    added_deposit = channel_deposit_bugbounty_limit - channel_deposit
-
-    # Fund accounts with tokens
-    token.transact({"from": owner}).transfer(sender, added_deposit + 1)
-
-    pre_balance = token.call().balanceOf(uraiden_instance.address)
-
-    with pytest.raises(tester.TransactionFailed):
-        token_instance.transact({"from": sender}).transfer(
-            uraiden_instance.address,
-            added_deposit + 1,
-            top_up_data
-        )
-    with pytest.raises(tester.TransactionFailed):
-        token_instance.transact({"from": sender}).transfer(
-            uraiden_instance.address,
-            added_deposit + 20,
-            top_up_data
-        )
-
-    token_instance.transact({"from": sender}).transfer(
-        uraiden_instance.address,
-        added_deposit,
-        top_up_data
-    )
-
-    post_balance = pre_balance + added_deposit
-    assert token_instance.call().balanceOf(uraiden_instance.address) == post_balance
-
-    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    assert channel_data[1] == channel_deposit_bugbounty_limit
-
-
 def test_channel_topup_20(
     get_accounts,
     uraiden_instance,
@@ -192,55 +142,6 @@ def test_channel_topup_20(
         channel_deposit + top_up_deposit)
     )
     ev_handler.check()
-
-
-def test_channel_topup_20_bounty_limit(
-    get_accounts,
-    owner,
-    uraiden_instance,
-    token_instance,
-    get_channel):
-    token = token_instance
-    (sender, receiver, A) = get_accounts(3)
-    channel_deposit = 1
-    channel = get_channel(uraiden_instance, token_instance, channel_deposit, sender, receiver)[:3]
-    (sender, receiver, open_block_number) = channel
-
-    # See how many tokens we need to reach channel_deposit_bugbounty_limit
-    added_deposit = channel_deposit_bugbounty_limit - channel_deposit
-
-    # Fund accounts with tokens
-    token.transact({"from": owner}).transfer(sender, added_deposit + 1)
-
-    # Approve token allowance
-    txn_hash = token.transact({"from": sender}).approve(uraiden_instance.address, added_deposit + 1)
-
-    pre_balance = token.call().balanceOf(uraiden_instance.address)
-
-    with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({'from': sender}).topUp(
-            receiver,
-            open_block_number,
-            added_deposit + 1
-        )
-    with pytest.raises(tester.TransactionFailed):
-        uraiden_instance.transact({'from': sender}).topUp(
-            receiver,
-            open_block_number,
-            added_deposit + 50
-        )
-
-    uraiden_instance.transact({'from': sender}).topUp(
-        receiver,
-        open_block_number,
-        added_deposit
-    )
-
-    post_balance = pre_balance + added_deposit
-    assert token_instance.call().balanceOf(uraiden_instance.address) == post_balance
-
-    channel_data = uraiden_instance.call().getChannelInfo(sender, receiver, open_block_number)
-    assert channel_data[1] == channel_deposit_bugbounty_limit
 
 
 def test_topup_token_fallback_uint_conversion(

--- a/contracts/tests/test_uraiden.py
+++ b/contracts/tests/test_uraiden.py
@@ -2,7 +2,6 @@ import pytest
 from ethereum import tester
 from eth_utils import encode_hex, is_same_address
 from tests.fixtures import (
-    channel_deposit_bugbounty_limit,
     uraiden_contract_version,
     challenge_period_min,
     contract_params,
@@ -72,9 +71,6 @@ def test_uraiden_init(
     assert token.call().balanceOf(uraiden.address) == 0
     assert web3.eth.getBalance(uraiden.address) == 0
 
-    # Temporary limit for the bug bounty release
-    assert uraiden.call().channel_deposit_bugbounty_limit() == channel_deposit_bugbounty_limit
-
 
 def test_variable_access(owner, uraiden_contract, token_instance, contract_params):
     uraiden = uraiden_contract(token_instance)
@@ -82,7 +78,6 @@ def test_variable_access(owner, uraiden_contract, token_instance, contract_param
     assert is_same_address(uraiden.call().token(), token_instance.address)
     assert uraiden.call().challenge_period() == contract_params['challenge_period']
     assert uraiden.call().version() == uraiden_contract_version
-    assert uraiden.call().channel_deposit_bugbounty_limit() == channel_deposit_bugbounty_limit
 
 
 def test_function_access(


### PR DESCRIPTION
Do not merge yet. Needs approval.

fixes https://github.com/raiden-network/microraiden/issues/316

Removes the bug bounty deposit limit. Now a channel can be opened / topped up up to `uint192`