### PR TITLE
Update eth ticker example

### DIFF
--- a/microraiden/microraiden/client/client.py
+++ b/microraiden/microraiden/client/client.py
@@ -13,7 +13,7 @@ from microraiden.utils import (
     create_signed_contract_transaction
 )
 
-import microraiden.config as config
+from microraiden.config import NETWORK_CFG
 from microraiden.constants import WEB3_PROVIDER_DEFAULT
 from microraiden.client.context import Context
 from microraiden.client.channel import Channel
@@ -45,8 +45,8 @@ class Client:
         if not web3:
             web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
 
-        channel_manager_address = (
-            channel_manager_address or config.CHANNEL_MANAGER_ADDRESS
+        channel_manager_address = to_checksum_address(
+            channel_manager_address or NETWORK_CFG.CHANNEL_MANAGER_ADDRESS
         )
 
         self.context = Context(private_key, web3, channel_manager_address)

--- a/microraiden/microraiden/examples/echo_server.py
+++ b/microraiden/microraiden/examples/echo_server.py
@@ -63,7 +63,7 @@ def run(
     #  - file for storing state information (balance proofs)
     if channel_manager is None:
         web3 = Web3(HTTPProvider(WEB3_PROVIDER_DEFAULT))
-        NETWORK_CFG.set_defaults(web3.version.network)
+        NETWORK_CFG.set_defaults(int(web3.version.network))
         channel_manager = make_channel_manager(
             private_key,
             NETWORK_CFG.CHANNEL_MANAGER_ADDRESS,

--- a/microraiden/microraiden/examples/eth_ticker.py
+++ b/microraiden/microraiden/examples/eth_ticker.py
@@ -26,7 +26,8 @@ def start_proxy(receiver_privkey: str) -> PaywalledProxy:
 
 
 class ETHTickerProxy:
-    def __init__(self, privkey: str, proxy: PaywalledProxy = None) -> None:
+    def __init__(self, privkey: str = None, proxy: PaywalledProxy = None) -> None:
+        assert privkey or proxy
         if proxy:
             self.app = proxy
         else:

--- a/microraiden/microraiden/examples/ticker_proxy.py
+++ b/microraiden/microraiden/examples/ticker_proxy.py
@@ -1,9 +1,27 @@
 from microraiden.examples.eth_ticker import ETHTickerProxy
-from microraiden.test.config import TEST_RECEIVER_PRIVKEY
 import logging
+import click
+from microraiden.click_helpers import main, pass_app
+
+
+@main.command()
+@click.option(
+    '--host',
+    default='localhost',
+    help='Address of the proxy'
+)
+@click.option(
+    '--port',
+    default=5000,
+    help='Port of the proxy'
+)
+@pass_app
+def start(app, host, port):
+    app.run(host=host, port=port, debug=True)  # nosec
+    proxy = ETHTickerProxy(proxy=app)
+    proxy.app.join()
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    proxy = ETHTickerProxy(TEST_RECEIVER_PRIVKEY)
-    proxy.app.join()
-    proxy.stop()
+    main()

--- a/microraiden/microraiden/test/fixtures/variables.py
+++ b/microraiden/microraiden/test/fixtures/variables.py
@@ -5,12 +5,10 @@ from ethereum.tester import keys
 import os
 import json
 from microraiden.utils import privkey_to_addr
-from microraiden.config import NETWORK_CFG
 from microraiden.constants import (
     CONTRACTS_ABI_JSON,
     CHANNEL_MANAGER_ABI_NAME,
     TOKEN_ABI_NAME,
-    get_network_id
 )
 
 
@@ -31,10 +29,7 @@ def proxy_ssl_certs(test_dir):
 
 @pytest.fixture(scope='session')
 def use_tester(request):
-    is_tester = request.config.getoption('use_tester')
-    if is_tester is True:
-        NETWORK_CFG.set_defaults(get_network_id('ethereum-tester'))
-    return is_tester
+    return request.config.getoption('use_tester')
 
 
 @pytest.fixture(scope='session')

--- a/microraiden/microraiden/test/fixtures/web3.py
+++ b/microraiden/microraiden/test/fixtures/web3.py
@@ -24,6 +24,9 @@ from microraiden.test.config import (
     FAUCET_ALLOWANCE,
     INITIAL_TOKEN_SUPPLY
 )
+from microraiden.constants import (
+    get_network_id
+)
 from microraiden.utils.contract import DEFAULT_TIMEOUT, DEFAULT_RETRY_INTERVAL
 import microraiden.utils.contract
 
@@ -121,6 +124,7 @@ def web3(use_tester: bool, faucet_private_key: str, faucet_address: str, mine_sy
     if use_tester:
         provider = EthereumTesterProvider()
         web3 = Web3(provider)
+        NETWORK_CFG.set_defaults(get_network_id('ethereum-tester'))
         x = web3.testing.mine
 
         def mine_patched(self, count):


### PR DESCRIPTION
- fix use of default channel manager address in client
- eth ticker proxy example uses a common `click` template