### PR TITLE
Add underflow check for failing faster.

### DIFF
--- a/contracts/contracts/RaidenMicroTransferChannels.sol
+++ b/contracts/contracts/RaidenMicroTransferChannels.sol
@@ -630,6 +630,7 @@ contract RaidenMicroTransferChannels {
 
         require(channel.open_block_number > 0);
         require(_balance <= channel.deposit);
+        require(withdrawn_balances[key] <= _balance);
 
         // Remove closed channel structures
         // channel.open_block_number will become 0


### PR DESCRIPTION
Issue raised in https://github.com/raiden-network/microraiden/issues/392 (add `require(withdrawn_balances[key] < _balance);` check in `settleChannel`)
To be discussed if this is really necessary.

In case the balance that has already been withdrawn is bigger than the closing balance, `settleChannel` would still fail without this underflow check when trying to transfer tokens to the receiver:
https://github.com/raiden-network/microraiden/blob/01346c05ac42abb9e4534888a64e0ca82d7fe448/contracts/contracts/RaidenMicroTransferChannels.sol#L642

In case of underflow:
```
receiver_remaining_tokens > token_instance.call().balanceOf(uraiden_instance.address)
```
due to already withdrawn tokens -> transaction would fail anyway.