### PR TITLE
Fix paywall url webui injection

### DIFF
--- a/microraiden/microraiden/proxy/resources/proxy_url.py
+++ b/microraiden/microraiden/proxy/resources/proxy_url.py
@@ -37,6 +37,8 @@ class PaywalledProxyUrl(Expensive):
 
     def get_paywall(self, url: str):
         data = self.get(url)
+        if data.headers['Content-Type'] != 'text/html':
+            return super().get_paywall(url)
 
 #  <link rel="stylesheet" type="text/css" href="/js/styles.css">
 


### PR DESCRIPTION
Paywalled proxy will present webui to the browser even if the content itself isn't a html page.

Fixes #395 