### PR TITLE
Temporary fix for Rinkeby - PoA extraData bytes

### DIFF
--- a/contracts/deploy/deploy_testnet.py
+++ b/contracts/deploy/deploy_testnet.py
@@ -11,6 +11,11 @@ from utils.utils import (
     check_succesful_tx,
     wait,
 )
+from web3 import Web3, HTTPProvider
+from web3.middleware.pythonic import (
+    pythonic_middleware,
+    to_hexbytes,
+)
 
 
 @click.command()
@@ -68,15 +73,21 @@ def main(**kwargs):
 
     assert challenge_period >= 500, 'Challenge period should be >= 500 blocks'
 
-    if chain_name == 'rinkeby':
-        txn_wait = 500
-
     print('''Make sure {} chain is running, you can connect to it and it is synced,
           or you'll get timeout'''.format(chain_name))
 
     with project.get_chain(chain_name) as chain:
         web3 = chain.web3
         print('Web3 provider is', web3.providers[0])
+
+        # Temporary fix for Rinkeby; PoA adds bytes to extraData, which is not yellow-paper-compliant
+        # https://github.com/ethereum/web3.py/issues/549
+        if int(web3.version.network) == 4:
+            txn_wait = 500
+            size_extraData_for_poa = 200   # can change
+
+            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByNumber'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)
+            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByHash'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)
 
         owner = owner or web3.eth.accounts[0]
         assert owner and is_address(owner), 'Invalid owner provided.'

--- a/contracts/deploy/deploy_testnet.py
+++ b/contracts/deploy/deploy_testnet.py
@@ -9,9 +9,7 @@ from eth_utils import (
 )
 from utils.utils import (
     check_succesful_tx,
-    wait,
 )
-from web3 import Web3, HTTPProvider
 from web3.middleware.pythonic import (
     pythonic_middleware,
     to_hexbytes,
@@ -80,14 +78,15 @@ def main(**kwargs):
         web3 = chain.web3
         print('Web3 provider is', web3.providers[0])
 
-        # Temporary fix for Rinkeby; PoA adds bytes to extraData, which is not yellow-paper-compliant
+        # Temporary fix for Rinkeby
+        # PoA adds bytes to extraData, which is not yellow-paper-compliant
         # https://github.com/ethereum/web3.py/issues/549
         if int(web3.version.network) == 4:
             txn_wait = 500
             size_extraData_for_poa = 200   # can change
 
-            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByNumber'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)
-            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByHash'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)
+            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByNumber'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)  # noqa
+            pythonic_middleware.__closure__[2].cell_contents['eth_getBlockByHash'].args[1].args[0]['extraData'] = to_hexbytes(size_extraData_for_poa, variable_length=True)  # noqa
 
         owner = owner or web3.eth.accounts[0]
         assert owner and is_address(owner), 'Invalid owner provided.'


### PR DESCRIPTION
fixes https://github.com/raiden-network/microraiden/issues/414

Temporary fix for Rinkeby; PoA adds bytes to extraData, which is not yellow-paper-compliant.
https://github.com/ethereum/web3.py/issues/549