### PR TITLE
Update package.json

### DIFF
--- a/microraiden/microraiden/webui/microraiden/package.json
+++ b/microraiden/microraiden/webui/microraiden/package.json
@@ -46,6 +46,7 @@
     "@types/core-js": "^0.9.43",
     "@types/mocha": "^2.2.45",
     "@types/node": "^8.5.2",
+    "@types/lodash": "^4.14.102",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
adding latest types/lodash

on npm@5.6.0, node@v9.5.0, Ubuntu16.04,
Build error occurs in typescript by saying;
```
node_modules/@types/lodash/index.d.ts:12651:53 - error TS2344: Type 'T' does not satisfy the constraint 'object'.

12651         isWeakSet<T>(value?: any): value is WeakSet<T>;
```

with 
```sudo npm install --save @types/lodash```
the build finishes without significant errors.