### PR TITLE
Freeze eth-abi to make Travis tests run again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cytoolz==0.8.2
 eth-utils>=0.7.4,<=0.7.9
 eth-keyfile==0.4.0
 eth-keys==0.1.0-beta.3
+eth-abi==0.5.0
 coincurve
 rlp>=0.4.3,<0.6.0
 flask


### PR DESCRIPTION
This is just a hotfix until populus fixes eth-abi incompatibility.