### PR TITLE
Dependencies fix: pycryptodome 3.5.0 build failure; flask/setuptools bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ eth-keys==0.1.0-beta.3
 coincurve>=7.1.0
 eth-abi==0.5.0
 rlp>=0.4.3,<0.6.0
-flask
+flask>=0.12
 flask_httpauth
 flask_restful
 ethereum<2.0.0,>=1.6.1


### PR DESCRIPTION
This will keep the used version of pycryptodome lower than 3.5.0, which encounters build failure (#455 ):
(https://github.com/Legrandin/pycryptodome/issues/142)


It will also make the non-pip setup routine with setuptools work (#438 ):
`python setup.py install`