### PR TITLE
Add ReadTheDocs deployment config

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,15 @@
+# additionally build PDF & ePub
+formats:
+    - epub
+    - pdf
+
+requirements_file: docs/requirements.txt
+
+build:
+    image: latest
+
+python:
+   version: 3.5
+   pip_install: true
+
+


### PR DESCRIPTION
This makes use of the beta functionality of the more advanced yaml-file based deployment configuration on http://readthedocs.io .
Particularly, this hopefully solves #438 by changing the default setuptools deployment to a pip installation.